### PR TITLE
Add EXPORT_CSV command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Mission: To provide a simple and intuitive way to manipulate tabular data in the
     * [X] **Integrate a DataFrame Library:** Switch to Danfo.js or DataFrame.js for robust data manipulation. (High Priority)
 2.  **I/O (Getting Data In & Out):**
     * [X] **LOAD_CSV (Better):** Implement `LOAD_CSV` using PapaParse.
-    * [ ] **Save to CSV:** Implement basic functionality to download the transformed data as a CSV.
+    * [X] **Save to CSV:** Implement basic functionality to download the transformed data as a CSV.
 3.  **Transformations (The "VLOOKUP" Core):**
     * [ ] **SELECT:** Implement function to select specific columns.
     * [ ] **JOIN (Inner Join):** Implement function to perform an inner join on two datasets based on a common key.

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <h3 class="text-lg font-semibold text-gray-700 mb-2">Syntax Guide:</h3>
             <ul class="list-disc list-inside text-sm text-gray-600 space-y-1">
                 <li>Start pipelines with `VAR "variableName"`.</li>
-                <li>Supported: `LOAD_CSV FILE "name"`, `KEEP_COLUMNS cols`, `PEEK`.</li>
+                <li>Supported: `LOAD_CSV FILE "name"`, `KEEP_COLUMNS cols`, `PEEK`, `EXPORT_CSV TO "name"`.</li>
                 <li>Other commands are parsed but not yet interpreted for all operations.</li>
                 <li>Piping: Use `THEN`. Comments: Start with `#`.</li>
                 <li>CSV Loading uses a basic native parser.</li>

--- a/js/ui.js
+++ b/js/ui.js
@@ -338,6 +338,8 @@ THEN
     LOAD_CSV FILE "cities.csv"
 THEN
     PEEK # Shows modified "citiesData"
+THEN
+    EXPORT_CSV TO "cities_out.csv" # Example export
 
 VAR "anotherVar"
 THEN

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "data_dsl",
+  "version": "1.0.0",
+  "description": "DSL for manipulating CSV data in the browser",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/interpreter.test.js
+++ b/tests/interpreter.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Interpreter } from '../js/interpreter.js';
+
+class MockDataFrame {
+  constructor(data) {
+    this.data = data;
+    this.columns = data.length ? Object.keys(data[0]) : [];
+    this.shape = [data.length, this.columns.length];
+  }
+  count() { return this.data.length; }
+  loc({ columns }) {
+    const newData = this.data.map(row => {
+      const obj = {};
+      columns.forEach(col => { obj[col] = row[col]; });
+      return obj;
+    });
+    return new MockDataFrame(newData);
+  }
+  toJSON() { return this.data; }
+}
+
+global.dfd = { DataFrame: MockDataFrame };
+global.Papa = { unparse: data => { global.__unparseCalled = true; return 'csv'; } };
+
+global.document = {
+  createElement: () => ({ click: () => { global.__clickCalled = true; } , set href(v){}, get href(){return ''}, set download(v){}, style:{} }),
+  body: { appendChild: () => {}, removeChild: () => {} }
+};
+
+test('handleKeepColumns selects columns case-insensitively', () => {
+  const interp = new Interpreter({});
+  interp.activeVariableName = 'd';
+  const df = new MockDataFrame([{A:1,B:2,C:3},{A:4,B:5,C:6}]);
+  const result = interp.handleKeepColumns({ columns: ['a','C'] }, df);
+  assert.deepEqual(result.columns, ['A','C']);
+  assert.strictEqual(result.shape[1], 2);
+});
+
+test('executeCommand PEEK stores peek output', async () => {
+  const interp = new Interpreter({});
+  interp.activeVariableName = 'data';
+  interp.variables.data = new MockDataFrame([{A:1}]);
+  await interp.executeCommand({ command: 'PEEK', args:{}, line:5 });
+  assert.strictEqual(interp.peekOutputs.length, 1);
+  assert.strictEqual(interp.peekOutputs[0].line, 5);
+});
+
+test('handleExportCsv exports DataFrame using Papa.unparse', async () => {
+  const interp = new Interpreter({});
+  interp.activeVariableName = 'data';
+  const df = new MockDataFrame([{A:1}]);
+  await interp.handleExportCsv({ file: 'out.csv' }, df);
+  assert.ok(global.__unparseCalled);
+  assert.ok(global.__clickCalled);
+  global.__unparseCalled = false;
+  global.__clickCalled = false;
+});
+
+test('handleExportCsv for array of objects uses Papa.unparse', async () => {
+  const interp = new Interpreter({});
+  interp.activeVariableName = 'data';
+  await interp.handleExportCsv({ file: 'arr.csv' }, [{A:1},{A:2}]);
+  assert.ok(global.__unparseCalled);
+  assert.ok(global.__clickCalled);
+  global.__unparseCalled = false;
+  global.__clickCalled = false;
+});
+
+test('handleExportCsv throws on unsupported type', async () => {
+  const interp = new Interpreter({});
+  interp.activeVariableName = 'data';
+  await assert.rejects(() => interp.handleExportCsv({file:'x.csv'}, 5), /does not support/);
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { tokenizeForParser } from '../js/tokenizer.js';
+import { Parser } from '../js/parser.js';
+
+test('Parser handles multiple VAR blocks', () => {
+  const script = `VAR "v1" THEN LOAD_CSV FILE "f.csv" THEN PEEK THEN EXPORT_CSV TO "out.csv"
+
+VAR "v2" THEN LOAD_EXCEL FILE "book.xlsx" SHEET "Sheet1" THEN PEEK`;
+  const tokens = tokenizeForParser(script);
+  const ast = new Parser(tokens).parse();
+  assert.strictEqual(ast.length, 2);
+  assert.strictEqual(ast[0].variableName, 'v1');
+  assert.strictEqual(ast[0].pipeline[0].command, 'LOAD_CSV');
+  assert.strictEqual(ast[0].pipeline.at(-1).command, 'EXPORT_CSV');
+  assert.strictEqual(ast[1].pipeline[0].command, 'LOAD_EXCEL');
+});
+
+test('Parser throws on missing THEN', () => {
+  const tokens = tokenizeForParser('VAR "x" PEEK');
+  const parser = new Parser(tokens);
+  assert.throws(() => parser.parse(), /must be followed by 'THEN'/);
+});

--- a/tests/tokenizer.test.js
+++ b/tests/tokenizer.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { tokenizeForParser, tokenizeForHighlighting, TokenType } from '../js/tokenizer.js';
+
+const sampleScript = `VAR "data" THEN LOAD_CSV FILE "cities.csv"
+# comment line
+THEN KEEP_COLUMNS name, population
+THEN PEEK`;
+
+test('tokenizeForParser produces expected token sequence', () => {
+  const tokens = tokenizeForParser(sampleScript);
+  const noNewlines = tokens.filter(t => t.type !== TokenType.NEWLINE);
+  const types = noNewlines.map(t => t.type);
+  assert.deepEqual(types, [
+    TokenType.KEYWORD,
+    TokenType.STRING_LITERAL,
+    TokenType.KEYWORD,
+    TokenType.KEYWORD,
+    TokenType.KEYWORD,
+    TokenType.STRING_LITERAL,
+    TokenType.KEYWORD,
+    TokenType.KEYWORD,
+    TokenType.IDENTIFIER,
+    TokenType.PUNCTUATION,
+    TokenType.IDENTIFIER,
+    TokenType.KEYWORD,
+    TokenType.KEYWORD,
+    TokenType.EOF
+  ]);
+  assert.strictEqual(noNewlines[0].value, 'VAR');
+  assert.strictEqual(noNewlines[1].value, 'data');
+  assert.strictEqual(noNewlines[3].value, 'LOAD_CSV');
+});
+
+test('tokenizeForHighlighting keeps comment and case', () => {
+  const tokens = tokenizeForHighlighting('Var "X"\n#hello');
+  const comment = tokens.find(t => t.type === TokenType.COMMENT);
+  assert.ok(comment && comment.value.includes('#hello'));
+  assert.strictEqual(tokens[0].value, 'Var');
+});


### PR DESCRIPTION
## Summary
- use PapaParse to export DataFrames and arrays to CSV
- adjust interpreter tests for PapaParse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fade70c508325b781024e177549d3