### PR TITLE
Add integration tests for parser and UI

### DIFF
--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -4,6 +4,8 @@ import { JSDOM } from 'jsdom';
 import { Interpreter } from '../js/interpreter.js';
 import { initUI, renderPeekOutputsUI } from '../js/ui.js';
 
+import { TokenType, tokenizeForParser, tokenizeForHighlighting } from "../js/tokenizer.js";
+import { Parser } from "../js/parser.js";
 function setupDom() {
   const dom = new JSDOM(`<!DOCTYPE html><body>
     <textarea id="pipeDataInput"></textarea>
@@ -65,9 +67,6 @@ THEN PEEK`;
 
   document.getElementById('pipeDataInput').value = script;
   document.getElementById('highlightingOverlay').innerHTML = '';
-
-  const { tokenizeForParser } = await import('../js/tokenizer.js');
-  const { Parser } = await import('../js/parser.js');
   const tokens = tokenizeForParser(script);
   const ast = new Parser(tokens).parse();
   document.getElementById('astOutput').textContent = JSON.stringify(ast, null, 2);
@@ -86,3 +85,93 @@ THEN PEEK`;
   assert.strictEqual(contents.length, 2);
   assert.ok(document.getElementById('astOutput').textContent.includes('LOAD_CSV'));
 });
+
+test('full chain handles multi-block script and empty dataset', async () => {
+  setupDom();
+  global.Papa = {
+    parse: (file, opts) => {
+      const rows = Array.from({length: 12}, (_, i) => ({A: i + 1, B: (i + 1) * 2}));
+      opts.complete({ data: rows, meta: { fields:['A','B'] } });
+    }
+  };
+
+  const uiEls = {
+    logOutputEl: document.getElementById('logOutput'),
+    csvFileInputEl: document.getElementById('csvFileInput'),
+    fileInputContainerEl: document.getElementById('fileInputContainer'),
+    filePromptMessageEl: document.getElementById('filePromptMessage')
+  };
+
+  const interp = new Interpreter(uiEls);
+  initUI(interp);
+  interp.requestCsvFile = async () => ({ name: 'fake.csv' });
+
+  const script = `VAR "main"
+THEN LOAD_CSV FILE "fake.csv" #load file
+THEN PEEK
+THEN SELECT A
+THEN PEEK
+
+VAR "other"
+THEN PEEK`;
+
+  document.getElementById('pipeDataInput').value = script;
+  document.getElementById('highlightingOverlay').innerHTML = '';
+
+  const highlightTokens = tokenizeForHighlighting(script);
+  assert.ok(highlightTokens.some(t => t.type === TokenType.COMMENT));
+  const tokens = tokenizeForParser(script);
+  const ast = new Parser(tokens).parse();
+  document.getElementById("astOutput").textContent = JSON.stringify(ast, null, 2);
+  await interp.run(ast);
+  renderPeekOutputsUI();
+
+  assert.strictEqual(ast.length, 2);
+  assert.strictEqual(interp.peekOutputs.length, 3);
+  assert.strictEqual(interp.peekOutputs[0].dataset.length, 12);
+  assert.deepEqual(interp.peekOutputs[1].dataset[0], {A:1});
+  assert.strictEqual(interp.peekOutputs[2].dataset, null);
+
+  const tabs = document.querySelectorAll('.peek-tab');
+  assert.strictEqual(tabs.length, 3);
+  const emptyHtml = document.getElementById(interp.peekOutputs[2].id).innerHTML;
+  assert.ok(emptyHtml.includes('No dataset loaded to PEEK.'));
+  const peekHtml = document.getElementById(interp.peekOutputs[0].id).innerHTML;
+  assert.ok(peekHtml.includes('Showing first 10 of 12'));
+  assert.ok(document.getElementById('highlightingOverlay').innerHTML.length > 0);
+});
+
+test('ui shows error message for invalid script', async () => {
+  setupDom();
+  const uiEls = {
+    logOutputEl: document.getElementById('logOutput'),
+    csvFileInputEl: document.getElementById('csvFileInput'),
+    fileInputContainerEl: document.getElementById('fileInputContainer'),
+    filePromptMessageEl: document.getElementById('filePromptMessage')
+  };
+  const interp = new Interpreter(uiEls);
+  initUI(interp);
+
+  const script = 'VAR "x" PEEK';
+  document.getElementById('pipeDataInput').value = script;
+  document.getElementById('highlightingOverlay').innerHTML = '';
+
+  let error;
+  try {
+    const tokens = tokenizeForParser(script);
+    const parser = new Parser(tokens);
+    await interp.run(parser.parse());
+  } catch (e) {
+    error = e;
+    document.getElementById('astOutput').classList.add('error-box');
+    document.getElementById('astOutput').textContent = `Error: ${e.message}`;
+  }
+
+  renderPeekOutputsUI();
+
+  assert.ok(error);
+  assert.ok(document.getElementById('astOutput').classList.contains('error-box'));
+  assert.strictEqual(interp.peekOutputs.length, 0);
+  assert.ok(document.getElementById('peekOutputsDisplayArea').textContent.includes('No PEEK outputs'));
+});
+


### PR DESCRIPTION
## Summary
- add more integration tests covering full pipeline from tokenization to UI
- verify multi-block scripts, comment preservation, and empty dataset peeks
- test UI error handling for invalid scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc5a7a35883259695e63dd5a8e83f