### PR TITLE
Add save/load script feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This project contains a browser-based DSL for manipulating CSV data. The JavaScr
 
 ## Environment Setup
 - Use Node **18+** (Node 20 is available in the Codex container).
-- Run `npm install` once to ensure dependencies are installed (currently there are none, but future dependencies may be added).
+- Run `npm install` once to ensure dependencies are installed
 - The demo can be viewed by opening `index.html` directly or by serving the repo with a simple HTTP server, e.g. `npx http-server` or `python -m http.server`.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ anything. Additionally the interpreter preloads `cities` and `people`
 variables with the same data so you can experiment without any `LOAD_CSV`
 commands.
 
-Scripts you write in the editor can be saved to your browser using the **Save Script** button and later restored with **Load Script**. The script is stored in `localStorage`.
+Scripts you write in the editor can be saved to your browser using the **Save Script** button
+and later restored with **Load Script**. The script is stored in `localStorage`.
+On browsers that support the File System Access API you can also **Open File** or
+**Save File** to work directly with `.pd` script files.
 
 --- 
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,7 @@ anything. Additionally the interpreter preloads `cities` and `people`
 variables with the same data so you can experiment without any `LOAD_CSV`
 commands.
 
-Scripts you write in the editor can be saved to your browser using the **Save Script** button
-and later restored with **Load Script**. The script is stored in `localStorage`.
-On browsers that support the File System Access API you can also **Open File** or
-**Save File** to work directly with `.pd` script files.
+With a supported browser you can **Open File** or **Save File** to work directly with `.pd` script files.
 
 --- 
 
@@ -67,7 +64,7 @@ On browsers that support the File System Access API you can also **Open File** o
     * [ ] **Cache Inputs:** Allow re-running scripts without re-uploading files (e.g., session-based cache or allow local file paths if feasible securely).
 2.  **I/O (More Formats & Script Management):**
     * [ ] **LOAD\_JSON:** Implement loading data from JSON files.
-    * [X] **Save/Load Scripts:** Allow users to save and load their PipeData scripts (e.g., using localStorage or file download/upload).
+    * [X] **Save/Load Scripts:** Allow users to save and load their PipeData scripts (e.g., using file download/upload).
 3.  **Transformations (Expanding the Toolkit):**
     * [ ] **FILTER:** Develop syntax and implement row filtering based on conditions.
     * [ ] **DROP:** Implement function to drop specified columns.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ anything. Additionally the interpreter preloads `cities` and `people`
 variables with the same data so you can experiment without any `LOAD_CSV`
 commands.
 
+Scripts you write in the editor can be saved to your browser using the **Save Script** button and later restored with **Load Script**. The script is stored in `localStorage`.
+
 --- 
 
 # PipeData Development Roadmap
@@ -62,7 +64,7 @@ commands.
     * [ ] **Cache Inputs:** Allow re-running scripts without re-uploading files (e.g., session-based cache or allow local file paths if feasible securely).
 2.  **I/O (More Formats & Script Management):**
     * [ ] **LOAD\_JSON:** Implement loading data from JSON files.
-    * [ ] **Save/Load Scripts:** Allow users to save and load their PipeData scripts (e.g., using localStorage or file download/upload).
+    * [X] **Save/Load Scripts:** Allow users to save and load their PipeData scripts (e.g., using localStorage or file download/upload).
 3.  **Transformations (Expanding the Toolkit):**
     * [ ] **FILTER:** Develop syntax and implement row filtering based on conditions.
     * [ ] **DROP:** Implement function to drop specified columns.

--- a/guide.md
+++ b/guide.md
@@ -91,8 +91,6 @@ parsed but currently have no effect in the interpreter.
 - Chain multiple commands with `THEN` to build a pipeline.
 - Comments can appear on their own line or after a command.
 - When loading a file, the UI will prompt you to select it.
-- Use **Save Script** to store your current script in the browser and
-  **Load Script** to retrieve it later.
-- With a supported browser you can also **Open File** or **Save File** to work
+- With a supported browser you can **Open File** or **Save File** to work
   with `.pd` files.
 

--- a/guide.md
+++ b/guide.md
@@ -91,4 +91,5 @@ parsed but currently have no effect in the interpreter.
 - Chain multiple commands with `THEN` to build a pipeline.
 - Comments can appear on their own line or after a command.
 - When loading a file, the UI will prompt you to select it.
+- Use **Save Script** to store your current script in the browser and **Load Script** to retrieve it later.
 

--- a/guide.md
+++ b/guide.md
@@ -91,5 +91,8 @@ parsed but currently have no effect in the interpreter.
 - Chain multiple commands with `THEN` to build a pipeline.
 - Comments can appear on their own line or after a command.
 - When loading a file, the UI will prompt you to select it.
-- Use **Save Script** to store your current script in the browser and **Load Script** to retrieve it later.
+- Use **Save Script** to store your current script in the browser and
+  **Load Script** to retrieve it later.
+- With a supported browser you can also **Open File** or **Save File** to work
+  with `.pd` files.
 

--- a/index.html
+++ b/index.html
@@ -19,14 +19,6 @@
                     <svg class="w-5 h-5 mr-1 github-icon-animated" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.73 1.27 3.4.97.11-.75.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.45.11-3.02 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 2.9-.39c.98.01 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.57.23 2.73.11 3.02.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.7.42.36.79 1.08.79 2.18 0 1.58-.01 2.85-.01 3.24 0 .31.21.68.8.56C20.71 21.39 24 17.08 24 12c0-6.27-5.23-11.5-12-11.5z"/>
                     </svg>
-                    
-                </a>
-                <a href="https://github.com/CodyBurker/data_dsl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline">
-                    View on GitHub
-                </a>
-                <a href="guide.html" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline ml-4">
-                    Language Guide
-                </a>
             </p>
         </header>
 

--- a/index.html
+++ b/index.html
@@ -15,11 +15,13 @@
             <h1 class="text-4xl font-bold text-gray-800">PipeData DSL Runner</h1>
             <p class="text-gray-600 mt-2">Write PipeData script, select a CSV if needed, and run to see results.</p>
             <p class="mt-1 text-right">
-                <a href="https://github.com/CodyBurker/data_dsl" target="_blank" rel="noopener noreferrer"
-                class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline">
+                <a href="https://github.com/CodyBurker/data_dsl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline">
                     <svg class="w-5 h-5 mr-1 github-icon-animated" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.73 1.27 3.4.97.11-.75.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.45.11-3.02 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 2.9-.39c.98.01 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.57.23 2.73.11 3.02.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.7.42.36.79 1.08.79 2.18 0 1.58-.01 2.85-.01 3.24 0 .31.21.68.8.56C20.71 21.39 24 17.08 24 12c0-6.27-5.23-11.5-12-11.5z"/>
                     </svg>
+                    
+                </a>
+                <a href="https://github.com/CodyBurker/data_dsl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline">
                     View on GitHub
                 </a>
                 <a href="guide.html" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline ml-4">

--- a/index.html
+++ b/index.html
@@ -44,14 +44,6 @@
                 <pre id="highlightingOverlay" aria-hidden="true"></pre>
             </div>
             <div class="mt-4 flex flex-col sm:flex-row justify-end items-center gap-4">
-                <button id="loadScriptButton"
-                    class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
-                    Load Script
-                </button>
-                <button id="saveScriptButton"
-                    class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
-                    Save Script
-                </button>
                 <button id="openScriptFileButton"
                     class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
                     Open File

--- a/index.html
+++ b/index.html
@@ -50,6 +50,14 @@
                     class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
                     Save Script
                 </button>
+                <button id="openScriptFileButton"
+                    class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    Open File
+                </button>
+                <button id="saveScriptFileButton"
+                    class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    Save File
+                </button>
                 <button id="clearButton"
                     class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
                     Clear Outputs

--- a/index.html
+++ b/index.html
@@ -19,6 +19,14 @@
                     <svg class="w-5 h-5 mr-1 github-icon-animated" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.73 1.27 3.4.97.11-.75.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.45.11-3.02 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 2.9-.39c.98.01 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.57.23 2.73.11 3.02.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.25 5.7.42.36.79 1.08.79 2.18 0 1.58-.01 2.85-.01 3.24 0 .31.21.68.8.56C20.71 21.39 24 17.08 24 12c0-6.27-5.23-11.5-12-11.5z"/>
                     </svg>
+                    
+                </a>
+                <a href="https://github.com/CodyBurker/data_dsl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline">
+                    View on GitHub
+                </a>
+                <a href="guide.html" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline ml-4">
+                    Language Guide
+                </a>
             </p>
         </header>
 

--- a/index.html
+++ b/index.html
@@ -42,6 +42,14 @@
                 <pre id="highlightingOverlay" aria-hidden="true"></pre>
             </div>
             <div class="mt-4 flex flex-col sm:flex-row justify-end items-center gap-4">
+                <button id="loadScriptButton"
+                    class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    Load Script
+                </button>
+                <button id="saveScriptButton"
+                    class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    Save Script
+                </button>
                 <button id="clearButton"
                     class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
                     Clear Outputs

--- a/js/ui.js
+++ b/js/ui.js
@@ -325,7 +325,7 @@ function loadScriptFromLocal() {
 async function saveScriptToFile() {
     if (!elements.inputArea || typeof window.showSaveFilePicker !== 'function') return;
     try {
-        const [handle] = await window.showSaveFilePicker({
+        const handle = await window.showSaveFilePicker({
             types: [{ description: 'PipeData Script', accept: { 'text/plain': ['.pd'] } }]
         });
         const writable = await handle.createWritable();

--- a/js/ui.js
+++ b/js/ui.js
@@ -340,7 +340,7 @@ export function initUI(interpreter) {
     queryElements(); // Get all DOM elements
 
     const defaultScript = `VAR "cities"
-        elements.inputArea.value = defaultScript;
+THEN LOAD_CSV FILE "exampleCities.csv"
 THEN SELECT population, id
 THEN PEEK
 VAR "people"

--- a/js/ui.js
+++ b/js/ui.js
@@ -18,8 +18,6 @@ function queryElements() {
     elements.peekOutputsDisplayAreaEl = document.getElementById('peekOutputsDisplayArea');
     elements.runButton = document.getElementById('runButton');
     elements.clearButton = document.getElementById('clearButton');
-    elements.saveButton = document.getElementById('saveScriptButton');
-    elements.loadButton = document.getElementById('loadScriptButton');
     elements.openFileButton = document.getElementById('openScriptFileButton');
     elements.saveFileButton = document.getElementById('saveScriptFileButton');
     elements.csvFileInputEl = document.getElementById('csvFileInput');
@@ -301,26 +299,6 @@ function handleExportPeek() {
 }
 // --- END NEW FUNCTION ---
 
-function saveScriptToLocal() {
-    if (!elements.inputArea) return;
-    localStorage.setItem('pipedata_saved_script', elements.inputArea.value);
-    if (uiInterpreterInstance) uiInterpreterInstance.log('Script saved to localStorage.');
-}
-
-function loadScriptFromLocal() {
-    if (!elements.inputArea) return;
-    const script = localStorage.getItem('pipedata_saved_script');
-    if (script !== null) {
-        elements.inputArea.value = script;
-        if (elements.highlightingOverlay) {
-            elements.highlightingOverlay.innerHTML = applySyntaxHighlighting(script, null);
-            currentEditorHighlightLine = null;
-        }
-        if (uiInterpreterInstance) uiInterpreterInstance.log('Loaded script from localStorage.');
-    } else {
-        alert('No saved script found.');
-    }
-}
 
 async function saveScriptToFile() {
     if (!elements.inputArea || typeof window.showSaveFilePicker !== 'function') return;
@@ -362,8 +340,7 @@ export function initUI(interpreter) {
     queryElements(); // Get all DOM elements
 
     const defaultScript = `VAR "cities"
-THEN LOAD_CSV FILE "exampleCities.csv"
-THEN PEEK
+        elements.inputArea.value = defaultScript;
 THEN SELECT population, id
 THEN PEEK
 VAR "people"
@@ -447,8 +424,6 @@ THEN PEEK`;
         clearOutputs();
     });
 
-    elements.saveButton?.addEventListener('click', saveScriptToLocal);
-    elements.loadButton?.addEventListener('click', loadScriptFromLocal);
     elements.saveFileButton?.addEventListener('click', saveScriptToFile);
     elements.openFileButton?.addEventListener('click', loadScriptFromFile);
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -18,6 +18,8 @@ function queryElements() {
     elements.peekOutputsDisplayAreaEl = document.getElementById('peekOutputsDisplayArea');
     elements.runButton = document.getElementById('runButton');
     elements.clearButton = document.getElementById('clearButton');
+    elements.saveButton = document.getElementById('saveScriptButton');
+    elements.loadButton = document.getElementById('loadScriptButton');
     elements.csvFileInputEl = document.getElementById('csvFileInput');
     elements.fileInputContainerEl = document.getElementById('fileInputContainer');
     elements.filePromptMessageEl = document.getElementById('filePromptMessage');
@@ -297,6 +299,27 @@ function handleExportPeek() {
 }
 // --- END NEW FUNCTION ---
 
+function saveScriptToLocal() {
+    if (!elements.inputArea) return;
+    localStorage.setItem('pipedata_saved_script', elements.inputArea.value);
+    if (uiInterpreterInstance) uiInterpreterInstance.log('Script saved to localStorage.');
+}
+
+function loadScriptFromLocal() {
+    if (!elements.inputArea) return;
+    const script = localStorage.getItem('pipedata_saved_script');
+    if (script !== null) {
+        elements.inputArea.value = script;
+        if (elements.highlightingOverlay) {
+            elements.highlightingOverlay.innerHTML = applySyntaxHighlighting(script, null);
+            currentEditorHighlightLine = null;
+        }
+        if (uiInterpreterInstance) uiInterpreterInstance.log('Loaded script from localStorage.');
+    } else {
+        alert('No saved script found.');
+    }
+}
+
 
 export function initUI(interpreter) {
     uiInterpreterInstance = interpreter; // Store interpreter instance for UI use
@@ -315,7 +338,8 @@ THEN
 THEN
     PEEK`;
     if (elements.inputArea) {
-        elements.inputArea.value = defaultScript;
+        const stored = localStorage.getItem('pipedata_saved_script');
+        elements.inputArea.value = stored || defaultScript;
         if (elements.highlightingOverlay) {
             elements.highlightingOverlay.innerHTML = applySyntaxHighlighting(elements.inputArea.value, null);
         }
@@ -387,6 +411,9 @@ THEN
     elements.clearButton?.addEventListener('click', () => {
         clearOutputs();
     });
+
+    elements.saveButton?.addEventListener('click', saveScriptToLocal);
+    elements.loadButton?.addEventListener('click', loadScriptFromLocal);
 
     // --- START NEW EVENT LISTENER ---
     elements.exportPeekButton?.addEventListener('click', handleExportPeek);

--- a/js/ui.js
+++ b/js/ui.js
@@ -20,6 +20,8 @@ function queryElements() {
     elements.clearButton = document.getElementById('clearButton');
     elements.saveButton = document.getElementById('saveScriptButton');
     elements.loadButton = document.getElementById('loadScriptButton');
+    elements.openFileButton = document.getElementById('openScriptFileButton');
+    elements.saveFileButton = document.getElementById('saveScriptFileButton');
     elements.csvFileInputEl = document.getElementById('csvFileInput');
     elements.fileInputContainerEl = document.getElementById('fileInputContainer');
     elements.filePromptMessageEl = document.getElementById('filePromptMessage');
@@ -320,6 +322,40 @@ function loadScriptFromLocal() {
     }
 }
 
+async function saveScriptToFile() {
+    if (!elements.inputArea || typeof window.showSaveFilePicker !== 'function') return;
+    try {
+        const [handle] = await window.showSaveFilePicker({
+            types: [{ description: 'PipeData Script', accept: { 'text/plain': ['.pd'] } }]
+        });
+        const writable = await handle.createWritable();
+        await writable.write(elements.inputArea.value);
+        await writable.close();
+        if (uiInterpreterInstance) uiInterpreterInstance.log('Script saved to file.');
+    } catch (e) {
+        // User cancelled
+    }
+}
+
+async function loadScriptFromFile() {
+    if (!elements.inputArea || typeof window.showOpenFilePicker !== 'function') return;
+    try {
+        const [handle] = await window.showOpenFilePicker({
+            types: [{ description: 'PipeData Script', accept: { 'text/plain': ['.pd', '.txt'] } }]
+        });
+        const file = await handle.getFile();
+        const text = await file.text();
+        elements.inputArea.value = text;
+        if (elements.highlightingOverlay) {
+            elements.highlightingOverlay.innerHTML = applySyntaxHighlighting(text, null);
+            currentEditorHighlightLine = null;
+        }
+        if (uiInterpreterInstance) uiInterpreterInstance.log('Loaded script from file.');
+    } catch (e) {
+        // User cancelled
+    }
+}
+
 
 export function initUI(interpreter) {
     uiInterpreterInstance = interpreter; // Store interpreter instance for UI use
@@ -413,6 +449,8 @@ THEN PEEK`;
 
     elements.saveButton?.addEventListener('click', saveScriptToLocal);
     elements.loadButton?.addEventListener('click', loadScriptFromLocal);
+    elements.saveFileButton?.addEventListener('click', saveScriptToFile);
+    elements.openFileButton?.addEventListener('click', loadScriptFromFile);
 
     // --- START NEW EVENT LISTENER ---
     elements.exportPeekButton?.addEventListener('click', handleExportPeek);

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -205,12 +205,12 @@ test('saving script to file uses File System Access API', async () => {
 
   let data = null;
   let closed = false;
-  window.showSaveFilePicker = async () => [{
+  window.showSaveFilePicker = async () => ({
     createWritable: async () => ({
       write: async d => { data = d; },
       close: async () => { closed = true; }
     })
-  }];
+  });
 
   document.getElementById('pipeDataInput').value = 'VAR "x"';
   document.getElementById('saveScriptFileButton').click();

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -14,8 +14,6 @@ function setupDom() {
     <div id="logOutput"></div>
     <div id="peekTabsContainer"></div>
     <div id="peekOutputsDisplayArea"></div>
-    <button id="loadScriptButton"></button>
-    <button id="saveScriptButton"></button>
     <button id="openScriptFileButton"></button>
     <button id="saveScriptFileButton"></button>
     <button id="runButton"></button>
@@ -27,7 +25,6 @@ function setupDom() {
   </body>`, { url: 'https://example.com' });
   global.document = dom.window.document;
   global.window = dom.window;
-  global.localStorage = dom.window.localStorage;
   global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
 }
 
@@ -180,23 +177,6 @@ test('ui shows error message for invalid script', async () => {
   assert.ok(document.getElementById('peekOutputsDisplayArea').textContent.includes('No PEEK outputs'));
 });
 
-test('saving and loading script with localStorage', () => {
-  setupDom();
-  const uiEls = {
-    logOutputEl: document.getElementById('logOutput'),
-  };
-  const interp = new Interpreter(uiEls);
-  initUI(interp);
-
-  const script = 'VAR "x"\nTHEN PEEK';
-  document.getElementById('pipeDataInput').value = script;
-  document.getElementById('saveScriptButton').click();
-  assert.strictEqual(window.localStorage.getItem('pipedata_saved_script'), script);
-
-  document.getElementById('pipeDataInput').value = '';
-  document.getElementById('loadScriptButton').click();
-  assert.strictEqual(document.getElementById('pipeDataInput').value, script);
-});
 
 test('saving script to file uses File System Access API', async () => {
   setupDom();

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -14,15 +14,18 @@ function setupDom() {
     <div id="logOutput"></div>
     <div id="peekTabsContainer"></div>
     <div id="peekOutputsDisplayArea"></div>
+    <button id="loadScriptButton"></button>
+    <button id="saveScriptButton"></button>
     <button id="runButton"></button>
     <button id="clearButton"></button>
     <input id="csvFileInput" />
     <div id="fileInputContainer"></div>
     <span id="filePromptMessage"></span>
     <button id="exportPeekButton"></button>
-  </body>`);
+  </body>`, { url: 'https://example.com' });
   global.document = dom.window.document;
   global.window = dom.window;
+  global.localStorage = dom.window.localStorage;
   global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
 }
 
@@ -173,5 +176,23 @@ test('ui shows error message for invalid script', async () => {
   assert.ok(document.getElementById('astOutput').classList.contains('error-box'));
   assert.strictEqual(interp.peekOutputs.length, 0);
   assert.ok(document.getElementById('peekOutputsDisplayArea').textContent.includes('No PEEK outputs'));
+});
+
+test('saving and loading script with localStorage', () => {
+  setupDom();
+  const uiEls = {
+    logOutputEl: document.getElementById('logOutput'),
+  };
+  const interp = new Interpreter(uiEls);
+  initUI(interp);
+
+  const script = 'VAR "x"\nTHEN PEEK';
+  document.getElementById('pipeDataInput').value = script;
+  document.getElementById('saveScriptButton').click();
+  assert.strictEqual(window.localStorage.getItem('pipedata_saved_script'), script);
+
+  document.getElementById('pipeDataInput').value = '';
+  document.getElementById('loadScriptButton').click();
+  assert.strictEqual(document.getElementById('pipeDataInput').value, script);
 });
 


### PR DESCRIPTION
## Summary
- add Save Script and Load Script buttons
- persist scripts to localStorage and allow loading
- update README and guide with info on saving scripts
- test save/load behaviour in UI tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405036cdb08325b991cdf0b2f8c705