### PR TITLE
Load default script from file and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ anything. Additionally the interpreter preloads `cities` and `people`
 variables with the same data so you can experiment without any `LOAD_CSV`
 commands.
 
+The editor automatically loads `examples/default.pd` on startup. The script shows
+how to compute `population_millions` with `WITH COLUMN`.
+
 With a supported browser you can **Open File** or **Save File** to work directly with `.pd` script files.
 
 --- 

--- a/examples/default.pd
+++ b/examples/default.pd
@@ -8,5 +8,5 @@ THEN LOAD_CSV FILE "examplePeople.csv"
 THEN PEEK
 THEN JOIN cities ON city_id=id TYPE "LEFT"
 THEN SELECT name, age, population, population_millions
-THEN FILTER name STARTSWITH "A"
+THEN FILTER name STARTSWITH "A" OR age < 30
 THEN PEEK

--- a/examples/default.pd
+++ b/examples/default.pd
@@ -8,5 +8,5 @@ THEN LOAD_CSV FILE "examplePeople.csv"
 THEN PEEK
 THEN JOIN cities ON city_id=id TYPE "LEFT"
 THEN SELECT name, age, population, population_millions
-THEN FILTER name STARTSWITH "A" OR age < 30
+THEN FILTER name STARTSWITH "A" OR (age < 30 and name contains "na")
 THEN PEEK

--- a/examples/default.pd
+++ b/examples/default.pd
@@ -1,0 +1,12 @@
+VAR "cities"
+THEN LOAD_CSV FILE "exampleCities.csv"
+THEN SELECT population, id
+THEN WITH COLUMN population_millions = population / 1000000
+THEN PEEK
+VAR "people"
+THEN LOAD_CSV FILE "examplePeople.csv"
+THEN PEEK
+THEN JOIN cities ON city_id=id TYPE "LEFT"
+THEN SELECT name, age, population, population_millions
+THEN FILTER name STARTSWITH "A"
+THEN PEEK

--- a/guide.md
+++ b/guide.md
@@ -109,4 +109,6 @@ parsed but currently have no effect in the interpreter.
 - When loading a file, the UI will prompt you to select it.
 - With a supported browser you can **Open File** or **Save File** to work
   with `.pd` files.
+- The editor loads `examples/default.pd` automatically so you can see a working
+  script right away.
 

--- a/js/main.js
+++ b/js/main.js
@@ -2,7 +2,7 @@
 import { Interpreter } from './interpreter.js';
 import { initUI } from './ui.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     // Query elements needed by the interpreter here, or ensure ui.js does it and provides them.
     // For simplicity, ui.js will query all elements it needs, including those for the interpreter.
     // The interpreter constructor in interpreter.js expects an object of these elements.
@@ -20,5 +20,5 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // initUI now takes the interpreter instance.
     // Parser and tokenizers are used directly within ui.js for the run button logic.
-    initUI(interpreter); 
+    await initUI(interpreter);
 });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -28,11 +28,11 @@ function setupDom() {
   global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
 }
 
-test('renderPeekOutputsUI creates a tab for each PEEK output', () => {
+test('renderPeekOutputsUI creates a tab for each PEEK output', async () => {
   setupDom();
 
   const interp = new Interpreter({});
-  initUI(interp);
+  await initUI(interp);
   interp.peekOutputs = [
     { id: 'p1', varName: 'x', line: 1, dataset: [{A:1}] },
     { id: 'p2', varName: 'x', line: 2, dataset: [{A:2}] }
@@ -58,7 +58,7 @@ test('running script updates AST output and peek UI', async () => {
   };
 
   const interp = new Interpreter(uiEls);
-  initUI(interp);
+  await initUI(interp);
   interp.requestCsvFile = async () => ({ name: 'fake.csv' });
 
   const script = `VAR "d"
@@ -105,7 +105,7 @@ test('full chain handles multi-block script and empty dataset', async () => {
   };
 
   const interp = new Interpreter(uiEls);
-  initUI(interp);
+  await initUI(interp);
   interp.requestCsvFile = async () => ({ name: 'fake.csv' });
 
   const script = `VAR "main"
@@ -152,7 +152,7 @@ test('ui shows error message for invalid script', async () => {
     filePromptMessageEl: document.getElementById('filePromptMessage')
   };
   const interp = new Interpreter(uiEls);
-  initUI(interp);
+  await initUI(interp);
 
   const script = 'VAR "x" PEEK';
   document.getElementById('pipeDataInput').value = script;
@@ -181,7 +181,7 @@ test('ui shows error message for invalid script', async () => {
 test('saving script to file uses File System Access API', async () => {
   setupDom();
   const interp = new Interpreter({});
-  initUI(interp);
+  await initUI(interp);
 
   let data = null;
   let closed = false;
@@ -203,7 +203,7 @@ test('saving script to file uses File System Access API', async () => {
 test('loading script from file populates editor', async () => {
   setupDom();
   const interp = new Interpreter({});
-  initUI(interp);
+  await initUI(interp);
 
   window.showOpenFilePicker = async () => [{
     getFile: async () => new File(['VAR "z"'], 'script.pd')


### PR DESCRIPTION
## Summary
- move sample script into `examples/default.pd`
- load the default script from file on page startup
- update README and guide docs
- make `initUI` async and adjust main & tests
- add integration test running the default script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407815411c8325b96a9a2b69f33278