### PR TITLE
Add step output tracking and update UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ variables with the same data so you can experiment without any `LOAD_CSV`
 commands.
 
 Every command execution now records its result in a **Step Outputs** list shown
-next to the PEEK outputs. Selecting a step highlights the first word of that
-line in the editor so you can trace pipeline execution. Moving the cursor onto a
-line with a recorded output automatically switches to that tab so you can
-quickly inspect results as you edit.
+next to the PEEK outputs. Only the active output tab is visible at any time and
+each tab label shows just the variable name. Selecting a step highlights the
+first word of that line in the editor so you can trace pipeline execution.
+Moving the cursor onto a line with a recorded output automatically switches to
+that tab so you can quickly inspect results as you edit.
 
 The editor automatically loads `examples/default.pd` on startup. The script shows
 how to compute `population_millions` with `WITH COLUMN`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ anything. Additionally the interpreter preloads `cities` and `people`
 variables with the same data so you can experiment without any `LOAD_CSV`
 commands.
 
+Every command execution now records its result in a **Step Outputs** list shown
+next to the PEEK outputs. Selecting a step highlights the corresponding line in
+the editor so you can trace pipeline execution.
+
 The editor automatically loads `examples/default.pd` on startup. The script shows
 how to compute `population_millions` with `WITH COLUMN`.
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ variables with the same data so you can experiment without any `LOAD_CSV`
 commands.
 
 Every command execution now records its result in a **Step Outputs** list shown
-next to the PEEK outputs. Selecting a step highlights the corresponding line in
-the editor so you can trace pipeline execution.
-Moving the cursor onto a line with a recorded output automatically switches to
-that tab so you can quickly inspect results as you edit.
+next to the PEEK outputs. Selecting a step highlights the first word of that
+line in the editor so you can trace pipeline execution. Moving the cursor onto a
+line with a recorded output automatically switches to that tab so you can
+quickly inspect results as you edit.
 
 The editor automatically loads `examples/default.pd` on startup. The script shows
 how to compute `population_millions` with `WITH COLUMN`.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ commands.
 Every command execution now records its result in a **Step Outputs** list shown
 next to the PEEK outputs. Selecting a step highlights the corresponding line in
 the editor so you can trace pipeline execution.
+Moving the cursor onto a line with a recorded output automatically switches to
+that tab so you can quickly inspect results as you edit.
 
 The editor automatically loads `examples/default.pd` on startup. The script shows
 how to compute `population_millions` with `WITH COLUMN`.

--- a/guide.md
+++ b/guide.md
@@ -65,10 +65,11 @@ Display the current dataset in the Peek output area.
 PEEK
 ```
 
-Each command also records its result in a **Step Outputs** list. Selecting a
-step tab highlights the first word of that command line so you can follow the
-pipeline. Placing the cursor on a line that produced a peek or step output will
-also activate the corresponding tab automatically.
+Each command also records its result in a **Step Outputs** list. Only the
+currently active output tab is shown, and each tab label displays the variable
+name only. Selecting a step tab highlights the first word of that command line
+so you can follow the pipeline. Placing the cursor on a line that produced a
+peek or step output will also activate the corresponding tab automatically.
 
 ### EXPORT_CSV
 Download the current dataset as a CSV file.

--- a/guide.md
+++ b/guide.md
@@ -67,6 +67,8 @@ PEEK
 
 Each command also records its result in a **Step Outputs** list. Selecting a
 step tab highlights that command in the editor so you can follow the pipeline.
+Placing the cursor on a line that produced a peek or step output will also
+activate the corresponding tab automatically.
 
 ### EXPORT_CSV
 Download the current dataset as a CSV file.

--- a/guide.md
+++ b/guide.md
@@ -66,9 +66,9 @@ PEEK
 ```
 
 Each command also records its result in a **Step Outputs** list. Selecting a
-step tab highlights that command in the editor so you can follow the pipeline.
-Placing the cursor on a line that produced a peek or step output will also
-activate the corresponding tab automatically.
+step tab highlights the first word of that command line so you can follow the
+pipeline. Placing the cursor on a line that produced a peek or step output will
+also activate the corresponding tab automatically.
 
 ### EXPORT_CSV
 Download the current dataset as a CSV file.

--- a/guide.md
+++ b/guide.md
@@ -65,6 +65,9 @@ Display the current dataset in the Peek output area.
 PEEK
 ```
 
+Each command also records its result in a **Step Outputs** list. Selecting a
+step tab highlights that command in the editor so you can follow the pipeline.
+
 ### EXPORT_CSV
 Download the current dataset as a CSV file.
 

--- a/js/interpreter.js
+++ b/js/interpreter.js
@@ -6,6 +6,7 @@ export class Interpreter {
         this.variables = {};
         this.activeVariableName = null;
         this.peekOutputs = [];
+        this.stepOutputs = [];
         this.fileResolve = null;
 
         // Store references to UI elements passed from ui.js
@@ -28,6 +29,7 @@ export class Interpreter {
         };
         this.activeVariableName = null;
         this.peekOutputs = [];
+        this.stepOutputs = [];
         this.fileResolve = null; // Should be reset if a run is interrupted
         this.log('Interpreter state cleared. Built-in samples loaded.');
     }
@@ -58,10 +60,14 @@ export class Interpreter {
             this.log(`Processing block for VAR "${this.activeVariableName}"`);
             this.variables[this.activeVariableName] = null;
 
-            for (const commandNode of varBlock.pipeline) {
+            for (let index = 0; index < varBlock.pipeline.length; index++) {
+                const commandNode = varBlock.pipeline[index];
                 this.log(`Executing: ${commandNode.command} for VAR "${this.activeVariableName}"` + (commandNode.line ? ` (Line ${commandNode.line})` : ''));
                 try {
                     await this.executeCommand(commandNode);
+                    const dataset = this.variables[this.activeVariableName];
+                    const stepId = `step-${this.activeVariableName}-l${commandNode.line}-${index}`;
+                    this.stepOutputs.push({ id: stepId, varName: this.activeVariableName, line: commandNode.line, dataset });
                 } catch (e) {
                     const err = e instanceof Error ? e.message : JSON.stringify(e);
                     this.log(`ERROR executing ${commandNode.command} for VAR "${this.activeVariableName}": ${err}`);

--- a/js/parser.js
+++ b/js/parser.js
@@ -88,27 +88,31 @@ export class Parser {
     parseCommand() {
         this.skipNewlines();
         const t = this.peek();
+        const startLine = t.line;
         if (t.type === TokenType.EOF) return null;
 
         if (t.type !== TokenType.KEYWORD) {
             this.error(`Expected command keyword but got ${t.type} '${t.value}'`);
         }
         switch (t.value) {
-            case 'LOAD_CSV': return this.parseLoadCsv();
-            case 'LOAD_EXCEL': return this.parseLoadExcel();
-            case 'KEEP_COLUMNS': return this.parseKeepColumns();
-            case 'SELECT': return this.parseSelect();
-            case 'DROP_COLUMNS': return this.parseDropColumns();
-            case 'FILTER': return this.parseFilter();
-            case 'WITH': return this.parseWithColumn();
-            case 'NEW_COLUMN': return this.parseNewColumn();
-            case 'RENAME_COLUMN': return this.parseRenameColumn();
-            case 'SORT_BY': return this.parseSortBy();
-            case 'JOIN': return this.parseJoin();
+            case 'LOAD_CSV': return { ...this.parseLoadCsv(), line: startLine };
+            case 'LOAD_EXCEL': return { ...this.parseLoadExcel(), line: startLine };
+            case 'KEEP_COLUMNS': return { ...this.parseKeepColumns(), line: startLine };
+            case 'SELECT': return { ...this.parseSelect(), line: startLine };
+            case 'DROP_COLUMNS': return { ...this.parseDropColumns(), line: startLine };
+            case 'FILTER': return { ...this.parseFilter(), line: startLine };
+            case 'WITH': return { ...this.parseWithColumn(), line: startLine };
+            case 'NEW_COLUMN': return { ...this.parseNewColumn(), line: startLine };
+            case 'RENAME_COLUMN': return { ...this.parseRenameColumn(), line: startLine };
+            case 'SORT_BY': return { ...this.parseSortBy(), line: startLine };
+            case 'JOIN': return { ...this.parseJoin(), line: startLine };
             // case 'STORE_AS': return this.parseStoreAs();
-            case 'EXPORT_CSV': return this.parseExportCsv();
-            case 'EXPORT_EXCEL': return this.parseExportExcel();
-            case 'PEEK': return this.parsePeek();
+            case 'EXPORT_CSV': return { ...this.parseExportCsv(), line: startLine };
+            case 'EXPORT_EXCEL': return { ...this.parseExportExcel(), line: startLine };
+            case 'PEEK': {
+                const pk = this.parsePeek();
+                return { ...pk, line: pk.line ?? startLine };
+            }
             default:
                 this.error(`Unexpected keyword '${t.value}' found where a command was expected.`);
                 return null;

--- a/js/ui.js
+++ b/js/ui.js
@@ -210,7 +210,7 @@ function renderPeekOutputsUI() {
     stepOutputs.forEach((stepData, index) => {
         const tabButton = document.createElement('button');
         tabButton.classList.add('peek-tab');
-        tabButton.textContent = `STEP ${index + 1} (VAR "${stepData.varName}", L${stepData.line})`;
+        tabButton.textContent = `STEP ${index + 1} (VAR "${stepData.varName}")`;
         tabButton.dataset.target = stepData.id;
         tabButton.dataset.stepIndex = index;
         tabButton.dataset.line = stepData.line;
@@ -253,7 +253,7 @@ function renderPeekOutputsUI() {
     peekOutputs.forEach((peekData, index) => {
         const tabButton = document.createElement('button');
         tabButton.classList.add('peek-tab');
-        tabButton.textContent = `PEEK ${index + 1} (VAR "${peekData.varName}", L${peekData.line})`;
+        tabButton.textContent = `PEEK ${index + 1} (VAR "${peekData.varName}")`;
         tabButton.dataset.target = peekData.id;
         tabButton.dataset.peekIndex = index; // Store index for easy data retrieval
         tabButton.dataset.line = peekData.line;

--- a/js/ui.js
+++ b/js/ui.js
@@ -210,7 +210,7 @@ function renderPeekOutputsUI() {
     stepOutputs.forEach((stepData, index) => {
         const tabButton = document.createElement('button');
         tabButton.classList.add('peek-tab');
-        tabButton.textContent = `STEP ${index + 1} (VAR "${stepData.varName}")`;
+        tabButton.textContent = stepData.varName;
         tabButton.dataset.target = stepData.id;
         tabButton.dataset.stepIndex = index;
         tabButton.dataset.line = stepData.line;
@@ -253,7 +253,7 @@ function renderPeekOutputsUI() {
     peekOutputs.forEach((peekData, index) => {
         const tabButton = document.createElement('button');
         tabButton.classList.add('peek-tab');
-        tabButton.textContent = `PEEK ${index + 1} (VAR "${peekData.varName}")`;
+        tabButton.textContent = peekData.varName;
         tabButton.dataset.target = peekData.id;
         tabButton.dataset.peekIndex = index; // Store index for easy data retrieval
         tabButton.dataset.line = peekData.line;

--- a/style.css
+++ b/style.css
@@ -310,10 +310,6 @@ body {
     /* A distinct yellow/orange highlight */
     border-radius: 3px;
     box-shadow: 0 0 5px rgba(255, 165, 0, 0.7);
-    padding: 0px 2px;
-    /* Minimal padding to not disrupt flow too much */
-    display: inline-block;
-    /* Ensures background and padding apply correctly */
 }
 
 /* Target the path within your animated SVG */

--- a/style.css
+++ b/style.css
@@ -262,6 +262,7 @@ body {
     font-size: 0.875rem;
     line-height: 1.25rem;
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    display: none;
 }
 
 #peekTabsContainer .peek-tab:hover {
@@ -280,6 +281,7 @@ body {
     /* Match border, bottom transparent to merge */
     position: relative;
     z-index: 1;
+    display: inline-block;
 }
 
 /* Individual PEEK content (initially hidden) */

--- a/style.css
+++ b/style.css
@@ -303,7 +303,7 @@ body {
     /* Shown when active */
 }
 
-.token-keyword.active-peek-line-highlight {
+.active-peek-line-highlight {
     background-color: rgba(255, 223, 100, 0.6);
     /* A distinct yellow/orange highlight */
     border-radius: 3px;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -40,6 +40,28 @@ test('renderPeekOutputsUI creates a tab for each PEEK output', async () => {
   renderPeekOutputsUI();
   const tabs = document.querySelectorAll('.peek-tab');
   assert.strictEqual(tabs.length, 2);
+  assert.strictEqual(tabs[1].dataset.line, '2');
+});
+
+test('moving cursor selects matching peek tab', async () => {
+  setupDom();
+
+  const interp = new Interpreter({});
+  await initUI(interp);
+  interp.peekOutputs = [
+    { id: 'p1', varName: 'x', line: 1, dataset: [{A:1}] },
+    { id: 'p2', varName: 'x', line: 2, dataset: [{A:2}] }
+  ];
+  renderPeekOutputsUI();
+
+  const input = document.getElementById('pipeDataInput');
+  input.value = 'LINE1\nLINE2';
+  input.setSelectionRange(6,6); // Start of line 2
+  input.dispatchEvent(new window.Event('keyup'));
+
+  const active = document.querySelector('.peek-tab.active-peek-tab');
+  assert.ok(active);
+  assert.strictEqual(active.dataset.line, '2');
 });
 
 test('running script updates AST output and peek UI', async () => {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -78,13 +78,14 @@ THEN PEEK`;
 
   assert.strictEqual(ast[0].pipeline.length, 4);
   assert.strictEqual(interp.peekOutputs.length, 2);
+  assert.strictEqual(interp.stepOutputs.length, 4);
   assert.deepEqual(interp.peekOutputs[0].dataset, [{A:1,B:2},{A:3,B:4}]);
   assert.deepEqual(interp.peekOutputs[1].dataset, [{A:1},{A:3}]);
 
   const tabs = document.querySelectorAll('.peek-tab');
-  assert.strictEqual(tabs.length, 2);
+  assert.strictEqual(tabs.length, interp.peekOutputs.length + interp.stepOutputs.length);
   const contents = document.querySelectorAll('.peek-content');
-  assert.strictEqual(contents.length, 2);
+  assert.strictEqual(contents.length, interp.peekOutputs.length + interp.stepOutputs.length);
   assert.ok(document.getElementById('astOutput').textContent.includes('LOAD_CSV'));
 });
 
@@ -130,12 +131,13 @@ THEN PEEK`;
 
   assert.strictEqual(ast.length, 2);
   assert.strictEqual(interp.peekOutputs.length, 3);
+  assert.strictEqual(interp.stepOutputs.length, 5);
   assert.strictEqual(interp.peekOutputs[0].dataset.length, 12);
   assert.deepEqual(interp.peekOutputs[1].dataset[0], {A:1});
   assert.strictEqual(interp.peekOutputs[2].dataset, null);
 
   const tabs = document.querySelectorAll('.peek-tab');
-  assert.strictEqual(tabs.length, 3);
+  assert.strictEqual(tabs.length, interp.peekOutputs.length + interp.stepOutputs.length);
   const emptyHtml = document.getElementById(interp.peekOutputs[2].id).innerHTML;
   assert.ok(emptyHtml.includes('No dataset loaded to PEEK.'));
   const peekHtml = document.getElementById(interp.peekOutputs[0].id).innerHTML;


### PR DESCRIPTION
## Summary
- capture dataset snapshot after each command and reset step outputs
- include command line numbers in parser results
- show step output tabs in the UI alongside peek outputs
- document new feature in README and guide
- update tests for new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684083905fac8325a0774dc93b4bc20d