### PR TITLE
Show dataset when clicking VAR line

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ each tab label shows just the variable name. Selecting a step highlights the
 first word of that line in the editor so you can trace pipeline execution.
 Moving the cursor onto a line with a recorded output automatically switches to
 that tab so you can quickly inspect results as you edit.
+Clicking on a line containing `VAR "name"` now shows the final value assigned to
+that variable after all of its commands run.
 
 The editor automatically loads `examples/default.pd` on startup. The script shows
 how to compute `population_millions` with `WITH COLUMN`.

--- a/guide.md
+++ b/guide.md
@@ -70,6 +70,8 @@ currently active output tab is shown, and each tab label displays the variable
 name only. Selecting a step tab highlights the first word of that command line
 so you can follow the pipeline. Placing the cursor on a line that produced a
 peek or step output will also activate the corresponding tab automatically.
+Clicking on the `VAR` line for a pipeline shows the dataset after all of that
+variable's commands have executed.
 
 ### EXPORT_CSV
 Download the current dataset as a CSV file.

--- a/js/interpreter.js
+++ b/js/interpreter.js
@@ -57,6 +57,7 @@ export class Interpreter {
 
         for (const varBlock of ast) {
             this.activeVariableName = varBlock.variableName;
+            const varLine = varBlock.line;
             this.log(`Processing block for VAR "${this.activeVariableName}"`);
             this.variables[this.activeVariableName] = null;
 
@@ -77,6 +78,10 @@ export class Interpreter {
                     return; // Stop execution on error
                 }
             }
+            // record final dataset for the VAR line itself
+            const finalDataset = this.variables[this.activeVariableName];
+            const finalStepId = `step-${this.activeVariableName}-l${varLine}-final`;
+            this.stepOutputs.push({ id: finalStepId, varName: this.activeVariableName, line: varLine, dataset: finalDataset });
             this.log(`Finished block for VAR "${this.activeVariableName}"`);
         }
         this.log('Interpreter finished all blocks.');

--- a/js/parser.js
+++ b/js/parser.js
@@ -27,9 +27,10 @@ export class Parser {
     }
 
     parseVarBlock() {
-        this.consume(TokenType.KEYWORD, 'VAR');
+        const varToken = this.consume(TokenType.KEYWORD, 'VAR');
         const variableNameToken = this.consume(TokenType.STRING_LITERAL, undefined, "Expected variable name as string literal after VAR (e.g., \"myVar\")");
         const variableName = variableNameToken.value;
+        const varLine = varToken.line;
 
         const commands = [];
         this.skipNewlines();
@@ -76,7 +77,7 @@ export class Parser {
         if (commands.length === 0) {
             this.error(`VAR "${variableName}" processing failed to identify commands (internal check).`);
         }
-        return { variableName: variableName, pipeline: commands };
+        return { variableName: variableName, line: varLine, pipeline: commands };
     }
 
     skipNewlines() {

--- a/tests/interpreter.test.js
+++ b/tests/interpreter.test.js
@@ -280,6 +280,6 @@ test('run records step outputs for each command', async () => {
     parse: (file, opts) => opts.complete({ data: [{A:1,B:2},{A:3,B:4}], meta:{ fields:['A','B'] } })
   };
   await interp.run(ast);
-  assert.strictEqual(interp.stepOutputs.length, ast[0].pipeline.length);
+  assert.strictEqual(interp.stepOutputs.length, ast[0].pipeline.length + 1);
   assert.deepEqual(interp.stepOutputs[1].dataset, [{A:1},{A:3}]);
 });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -100,7 +100,7 @@ THEN PEEK`;
 
   assert.strictEqual(ast[0].pipeline.length, 4);
   assert.strictEqual(interp.peekOutputs.length, 2);
-  assert.strictEqual(interp.stepOutputs.length, 4);
+  assert.strictEqual(interp.stepOutputs.length, 5);
   assert.deepEqual(interp.peekOutputs[0].dataset, [{A:1,B:2},{A:3,B:4}]);
   assert.deepEqual(interp.peekOutputs[1].dataset, [{A:1},{A:3}]);
 
@@ -153,7 +153,7 @@ THEN PEEK`;
 
   assert.strictEqual(ast.length, 2);
   assert.strictEqual(interp.peekOutputs.length, 3);
-  assert.strictEqual(interp.stepOutputs.length, 5);
+  assert.strictEqual(interp.stepOutputs.length, 7);
   assert.strictEqual(interp.peekOutputs[0].dataset.length, 12);
   assert.deepEqual(interp.peekOutputs[1].dataset[0], {A:1});
   assert.strictEqual(interp.peekOutputs[2].dataset, null);


### PR DESCRIPTION
## Summary
- track line number when parsing `VAR` blocks
- record final dataset after running each VAR block
- adjust tests for new step outputs
- document that clicking a VAR line shows its final value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68408cd05f4c832597d0359c02e04893