### PR TITLE
Add variable block indicator line

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
             <label for="pipeDataInput" class="block text-lg font-medium text-gray-700 mb-1">PipeData Script Editor:</label>
             <div class="code-editor-container editor-prominent">
                 <pre id="lineNumbers" aria-hidden="true"></pre>
+                <div id="varBlockIndicator" aria-hidden="true"></div>
                 <textarea id="pipeDataInput" spellcheck="false" autocomplete="off" autocapitalize="off"
                     placeholder="# Example: VAR &quot;myVar&quot; THEN LOAD_CSV FILE &quot;your_file.csv&quot;..."></textarea>
                 <pre id="highlightingOverlay" aria-hidden="true"></pre>

--- a/js/ui.js
+++ b/js/ui.js
@@ -20,6 +20,7 @@ function queryElements() {
     elements.inputArea = document.getElementById('pipeDataInput');
     elements.highlightingOverlay = document.getElementById('highlightingOverlay');
     elements.lineNumbers = document.getElementById('lineNumbers');
+    elements.varBlockIndicator = document.getElementById('varBlockIndicator');
     elements.astOutputArea = document.getElementById('astOutput');
     elements.logOutputEl = document.getElementById('logOutput');
     elements.peekTabsContainerEl = document.getElementById('peekTabsContainer');
@@ -257,6 +258,7 @@ function renderPeekOutputsUI() {
                         elements.highlightingOverlay.scrollTop = elements.inputArea.scrollTop;
                     }
                 }
+                updateVarBlockIndicator(stepData.line);
             }
         });
 
@@ -304,6 +306,7 @@ function renderPeekOutputsUI() {
                         elements.highlightingOverlay.scrollTop = elements.inputArea.scrollTop;
                     }
                 }
+                updateVarBlockIndicator(peekData.line);
             }
         });
 
@@ -339,6 +342,45 @@ function showOutputForLine(lineNumber) {
     }
 }
 
+function updateVarBlockIndicator(lineNumber) {
+    if (!elements.varBlockIndicator || !elements.inputArea) return;
+    const lines = elements.inputArea.value.split(/\r?\n/);
+    if (lineNumber < 1 || lineNumber > lines.length) {
+        elements.varBlockIndicator.style.display = 'none';
+        return;
+    }
+
+    let start = null;
+    for (let i = lineNumber - 1; i >= 0; i--) {
+        if (/^\s*VAR\b/i.test(lines[i])) { start = i + 1; break; }
+    }
+    if (start === null) {
+        elements.varBlockIndicator.style.display = 'none';
+        return;
+    }
+    let end = lines.length;
+    for (let i = lineNumber; i < lines.length; i++) {
+        if (/^\s*VAR\b/i.test(lines[i])) { end = i; break; }
+        if (/^\s*THEN\s+PEEK\b/i.test(lines[i])) { end = i + 1; break; }
+    }
+
+    const style = getComputedStyle(elements.inputArea);
+    const lineHeight = parseFloat(style.lineHeight);
+    const paddingTop = parseFloat(style.paddingTop);
+    const paddingLeft = parseFloat(style.paddingLeft);
+    const borderLeft = parseFloat(style.borderLeftWidth);
+    const borderTop = parseFloat(style.borderTopWidth);
+
+    const top = paddingTop + borderTop + (start - 1) * lineHeight - elements.inputArea.scrollTop;
+    const height = (end - start + 1) * lineHeight;
+    const left = paddingLeft + borderLeft - elements.inputArea.scrollLeft - 2;
+
+    elements.varBlockIndicator.style.top = `${top}px`;
+    elements.varBlockIndicator.style.left = `${left}px`;
+    elements.varBlockIndicator.style.height = `${height}px`;
+    elements.varBlockIndicator.style.display = 'block';
+}
+
 
 function clearOutputs() {
     if (uiInterpreterInstance) {
@@ -362,6 +404,7 @@ function clearOutputs() {
     }
     if (elements.exportPeekButton) elements.exportPeekButton.classList.add('hidden'); // <-- Hide export button
     clearEditorPeekHighlight();
+    if (elements.varBlockIndicator) elements.varBlockIndicator.style.display = 'none';
 }
 
 // --- START NEW FUNCTION ---
@@ -484,6 +527,7 @@ export async function initUI(interpreter) {
         if (elements.highlightingOverlay) {
             elements.highlightingOverlay.innerHTML = applySyntaxHighlighting(defaultScript, null);
         }
+        if (elements.varBlockIndicator) updateVarBlockIndicator(1);
     }
     clearOutputs(); // Initial clear
 
@@ -494,12 +538,16 @@ export async function initUI(interpreter) {
         currentEditorHighlightLine = null;
         elements.highlightingOverlay.scrollTop = elements.inputArea.scrollTop;
         elements.highlightingOverlay.scrollLeft = elements.inputArea.scrollLeft;
+        const line = getCursorLineNumber();
+        if (line) updateVarBlockIndicator(line);
     });
 
     elements.inputArea?.addEventListener('scroll', () => {
         elements.highlightingOverlay.scrollTop = elements.inputArea.scrollTop;
         elements.highlightingOverlay.scrollLeft = elements.inputArea.scrollLeft;
         updateLineNumbers();
+        const line = getCursorLineNumber();
+        if (line) updateVarBlockIndicator(line);
     });
 
     if (elements.inputArea) {
@@ -567,11 +615,17 @@ export async function initUI(interpreter) {
 
     elements.inputArea?.addEventListener('keyup', () => {
         const line = getCursorLineNumber();
-        if (line) showOutputForLine(line);
+        if (line) {
+            showOutputForLine(line);
+            updateVarBlockIndicator(line);
+        }
     });
     elements.inputArea?.addEventListener('click', () => {
         const line = getCursorLineNumber();
-        if (line) showOutputForLine(line);
+        if (line) {
+            showOutputForLine(line);
+            updateVarBlockIndicator(line);
+        }
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -108,6 +108,16 @@ body {
     pointer-events: none;
 }
 
+#varBlockIndicator {
+    position: absolute;
+    width: 2px;
+    background-color: #4f46e5;
+    opacity: 0.75;
+    z-index: 1;
+    pointer-events: none;
+    display: none;
+}
+
 #pipeDataInput,
 #highlightingOverlay {
     margin: 0;


### PR DESCRIPTION
## Summary
- add a vertical indicator div in the editor
- style the indicator
- calculate active variable block range and show indicator
- update event handlers to move indicator

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684092ba99ac832583e07e2eb106c497