### PR TITLE
Add execution status gutter with realtime updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ The script editor now includes a subtle line number gutter so you can quickly
 reference line positions while tracing your pipelines.
 
 An adjacent status gutter now shows which lines executed. Green bars mark
-completed lines while yellow bars indicate lines that have yet to run when an
-error occurs. The interpreter runs automatically a moment after you stop typing.
+completed lines, yellow bars mark steps that haven't run yet, and red bars
+highlight syntax errors. Blank lines remain uncolored. The interpreter runs
+automatically a moment after you stop typing.
 
 The editor automatically loads `examples/default.pd` on startup. The script shows
 how to compute `population_millions` with `WITH COLUMN`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ that variable after all of its commands run.
 The script editor now includes a subtle line number gutter so you can quickly
 reference line positions while tracing your pipelines.
 
+An adjacent status gutter now shows which lines executed. Green bars mark
+completed lines while yellow bars indicate lines that have yet to run when an
+error occurs. The interpreter runs automatically a moment after you stop typing.
+
 The editor automatically loads `examples/default.pd` on startup. The script shows
 how to compute `population_millions` with `WITH COLUMN`.
 

--- a/guide.md
+++ b/guide.md
@@ -74,9 +74,10 @@ Clicking on the `VAR` line for a pipeline shows the dataset after all of that
 variable's commands have executed.
 The editor shows line numbers so you can easily reference pipeline steps.
 Next to these numbers a thin gutter displays execution status. Lines that have
-run successfully show green bars, while lines after a parsing or runtime error
-remain yellow. The interpreter automatically reruns the script after brief
-pauses in typing so the preview stays current.
+run successfully show green bars, pending steps are yellow, and syntax errors
+highlight in red. Blank lines are left without color. The interpreter
+automatically reruns the script after brief pauses in typing so the preview
+stays current.
 
 ### EXPORT_CSV
 Download the current dataset as a CSV file.

--- a/guide.md
+++ b/guide.md
@@ -73,6 +73,10 @@ peek or step output will also activate the corresponding tab automatically.
 Clicking on the `VAR` line for a pipeline shows the dataset after all of that
 variable's commands have executed.
 The editor shows line numbers so you can easily reference pipeline steps.
+Next to these numbers a thin gutter displays execution status. Lines that have
+run successfully show green bars, while lines after a parsing or runtime error
+remain yellow. The interpreter automatically reruns the script after brief
+pauses in typing so the preview stays current.
 
 ### EXPORT_CSV
 Download the current dataset as a CSV file.

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
             <label for="pipeDataInput" class="block text-lg font-medium text-gray-700 mb-1">PipeData Script Editor:</label>
             <div class="code-editor-container editor-prominent">
                 <pre id="lineNumbers" aria-hidden="true"></pre>
+                <div id="execStatus" aria-hidden="true"></div>
                 <div id="varBlockIndicator" aria-hidden="true"></div>
                 <textarea id="pipeDataInput" spellcheck="false" autocomplete="off" autocapitalize="off"
                     placeholder="# Example: VAR &quot;myVar&quot; THEN LOAD_CSV FILE &quot;your_file.csv&quot;..."></textarea>

--- a/js/interpreter.js
+++ b/js/interpreter.js
@@ -213,4 +213,11 @@ export class Interpreter {
         }
     }
 
+    getExecutedLines() {
+        const lines = new Set();
+        for (const out of this.stepOutputs) {
+            if (typeof out.line === "number") lines.add(out.line);
+        }
+        return Array.from(lines);
+    }
 }

--- a/js/ui/elements.js
+++ b/js/ui/elements.js
@@ -8,6 +8,7 @@ function queryElements() {
     elements.inputArea = document.getElementById('pipeDataInput');
     elements.highlightingOverlay = document.getElementById('highlightingOverlay');
     elements.lineNumbers = document.getElementById('lineNumbers');
+    elements.execStatus = document.getElementById('execStatus');
     elements.varBlockIndicator = document.getElementById('varBlockIndicator');
     elements.astOutputArea = document.getElementById('astOutput');
     elements.logOutputEl = document.getElementById('logOutput');

--- a/style.css
+++ b/style.css
@@ -129,6 +129,11 @@ body {
     height: 1.5em;
 }
 
+.line-error {
+    background-color: #f87171;
+    height: 1.5em;
+}
+
 #varBlockIndicator {
     position: absolute;
     width: 2px;

--- a/style.css
+++ b/style.css
@@ -108,6 +108,27 @@ body {
     pointer-events: none;
 }
 
+#execStatus {
+    position: absolute;
+    top: 0;
+    left: 4ch;
+    width: 4px;
+    height: 100%;
+    overflow: hidden;
+    user-select: none;
+    pointer-events: none;
+}
+
+.line-success {
+    background-color: #34d399;
+    height: 1.5em;
+}
+
+.line-pending {
+    background-color: #facc15;
+    height: 1.5em;
+}
+
 #varBlockIndicator {
     position: absolute;
     width: 2px;
@@ -122,7 +143,7 @@ body {
 #highlightingOverlay {
     margin: 0;
     padding: 0.75rem;
-    padding-left: calc(0.75rem + 4.5ch);
+    padding-left: calc(0.75rem + 4.5ch + 4px);
     border-width: 1px;
     border-style: solid;
     border-color: #d1d5db;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -272,7 +272,7 @@ test('debounced input updates execStatus', async () => {
   assert.ok(Array.from(bars).every(b => b.classList.contains('line-success')));
 });
 
-test('execStatus shows pending on parse error', async () => {
+test('execStatus highlights error line in red', async () => {
   setupDom();
   const interp = new Interpreter({});
   await initUI(interp);
@@ -282,6 +282,31 @@ test('execStatus shows pending on parse error', async () => {
   await new Promise(r => setTimeout(r, 400));
   const bars = document.querySelectorAll('#execStatus div');
   assert.strictEqual(bars.length, 1);
-  assert.ok(bars[0].classList.contains('line-pending'));
+  assert.ok(bars[0].classList.contains('line-error'));
+});
+
+test('blank lines remain uncolored', async () => {
+  setupDom();
+  global.Papa = { parse: (f, o) => o.complete({ data: [], meta: { fields: [] } }) };
+  const uiEls = {
+    logOutputEl: document.getElementById('logOutput'),
+    csvFileInputEl: document.getElementById('csvFileInput'),
+    fileInputContainerEl: document.getElementById('fileInputContainer'),
+    filePromptMessageEl: document.getElementById('filePromptMessage')
+  };
+  const interp = new Interpreter(uiEls);
+  await initUI(interp);
+
+  const input = document.getElementById('pipeDataInput');
+  input.value = 'VAR "a"\nTHEN PEEK\n\nVAR "b"\nTHEN PEEK\n';
+  input.dispatchEvent(new window.Event('input'));
+  await new Promise(r => setTimeout(r, 400));
+
+  const bars = document.querySelectorAll('#execStatus div');
+  assert.strictEqual(bars.length, 6);
+  assert.ok(!bars[2].classList.contains('line-pending'));
+  assert.ok(!bars[2].classList.contains('line-success'));
+  assert.ok(!bars[5].classList.contains('line-pending'));
+  assert.ok(!bars[5].classList.contains('line-success'));
 });
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -10,6 +10,9 @@ function setupDom() {
   const dom = new JSDOM(`<!DOCTYPE html><body>
     <textarea id="pipeDataInput"></textarea>
     <div id="highlightingOverlay"></div>
+    <pre id="lineNumbers"></pre>
+    <div id="execStatus"></div>
+    <div id="varBlockIndicator"></div>
     <pre id="astOutput"></pre>
     <div id="logOutput"></div>
     <div id="peekTabsContainer"></div>
@@ -26,6 +29,13 @@ function setupDom() {
   global.document = dom.window.document;
   global.window = dom.window;
   global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
+  global.getComputedStyle = () => ({
+    lineHeight: '16px',
+    paddingTop: '0',
+    paddingLeft: '0',
+    borderLeftWidth: '0',
+    borderTopWidth: '0'
+  });
 }
 
 test('renderPeekOutputsUI creates a tab for each PEEK output', async () => {
@@ -238,5 +248,40 @@ test('loading script from file populates editor', async () => {
   await new Promise(r => setTimeout(r, 0));
 
   assert.strictEqual(document.getElementById('pipeDataInput').value, 'VAR "z"');
+});
+
+test('debounced input updates execStatus', async () => {
+  setupDom();
+  global.Papa = { parse: (f, o) => o.complete({ data: [], meta: { fields: [] } }) };
+  const uiEls = {
+    logOutputEl: document.getElementById('logOutput'),
+    csvFileInputEl: document.getElementById('csvFileInput'),
+    fileInputContainerEl: document.getElementById('fileInputContainer'),
+    filePromptMessageEl: document.getElementById('filePromptMessage')
+  };
+  const interp = new Interpreter(uiEls);
+  await initUI(interp);
+
+  const input = document.getElementById('pipeDataInput');
+  input.value = 'VAR "x"\nTHEN PEEK';
+  input.dispatchEvent(new window.Event('input'));
+  await new Promise(r => setTimeout(r, 400));
+
+  const bars = document.querySelectorAll('#execStatus div');
+  assert.strictEqual(bars.length, 2);
+  assert.ok(Array.from(bars).every(b => b.classList.contains('line-success')));
+});
+
+test('execStatus shows pending on parse error', async () => {
+  setupDom();
+  const interp = new Interpreter({});
+  await initUI(interp);
+  const input = document.getElementById('pipeDataInput');
+  input.value = 'VAR "x" PEEK';
+  input.dispatchEvent(new window.Event('input'));
+  await new Promise(r => setTimeout(r, 400));
+  const bars = document.querySelectorAll('#execStatus div');
+  assert.strictEqual(bars.length, 1);
+  assert.ok(bars[0].classList.contains('line-pending'));
 });
 


### PR DESCRIPTION
## Summary
- display execution status via new `.line-success` and `.line-pending` styles
- add `#execStatus` gutter in the editor and track it in UI logic
- run interpreter on debounced input and color executed lines
- expose `getExecutedLines` helper from interpreter
- document new behaviour in README and guide
- cover realtime status with jsdom tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b6e02f888325aeaa5daf672eb681