### PR TITLE
Support multiple parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ reference line positions while tracing your pipelines.
 
 An adjacent status gutter now shows which lines executed. Green bars mark
 completed lines, yellow bars mark steps that haven't run yet, and red bars
-highlight syntax errors. When a parse error occurs a red dot appears next to that line and hovering it shows the message. Blank lines within a VAR block inherit the color of the
+highlight syntax errors. When parse errors occur red dots appear next to each bad line and hovering them shows the messages. Blank lines within a VAR block inherit the color of the
 preceding command, while gaps between blocks stay uncolored. The interpreter runs
 automatically a moment after you stop typing.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ reference line positions while tracing your pipelines.
 
 An adjacent status gutter now shows which lines executed. Green bars mark
 completed lines, yellow bars mark steps that haven't run yet, and red bars
-highlight syntax errors. When parse errors occur red dots appear next to each bad line and hovering them shows the messages. Blank lines within a VAR block inherit the color of the
+highlight syntax errors. When parse errors occur red dots appear next to each bad line and hovering them shows the messages. Parsing now continues within a block so only the lines with issues are highlighted. Blank lines within a VAR block inherit the color of the
 preceding command, while gaps between blocks stay uncolored. The interpreter runs
 automatically a moment after you stop typing.
 

--- a/guide.md
+++ b/guide.md
@@ -66,7 +66,7 @@ output will also activate the corresponding tab automatically. Clicking on the
 commands have executed. The editor shows line numbers so you can easily
 reference pipeline steps. Next to these numbers a thin gutter displays
 execution status. Lines that have run successfully show green bars, pending
-steps are yellow, and syntax errors highlight in red. If parsing fails a red dot appears next to the offending line and hovering it reveals the error. Blank lines inside a VAR
+steps are yellow, and syntax errors highlight in red. If parsing fails red dots appear next to each offending line and hovering reveals the messages. Blank lines inside a VAR
 block inherit the previous line's color, while blank lines between blocks stay
 uncolored. The interpreter automatically reruns the script after brief
 pauses in typing so the preview stays current.

--- a/guide.md
+++ b/guide.md
@@ -66,7 +66,7 @@ output will also activate the corresponding tab automatically. Clicking on the
 commands have executed. The editor shows line numbers so you can easily
 reference pipeline steps. Next to these numbers a thin gutter displays
 execution status. Lines that have run successfully show green bars, pending
-steps are yellow, and syntax errors highlight in red. If parsing fails red dots appear next to each offending line and hovering reveals the messages. Blank lines inside a VAR
+steps are yellow, and syntax errors highlight in red. If parsing fails red dots appear next to each offending line and hovering reveals the messages. Parsing continues inside a block so only the faulty lines are marked. Blank lines inside a VAR
 block inherit the previous line's color, while blank lines between blocks stay
 uncolored. The interpreter automatically reruns the script after brief
 pauses in typing so the preview stays current.

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -145,3 +145,18 @@ test('parseAll collects multiple errors', () => {
   assert.ok(result.errors[0].line);
   assert.ok(result.errors[1].line);
 });
+
+test('parseAll continues parsing within a block after an error', () => {
+  const script = [
+    'VAR "cities"',
+    'THEN LOAD_CSV FILE "exampleCities.csv"',
+    'THEN WITH COLUMN population_millions = population / 1000000',
+    'THEN WITH COLUMN COL city_of = "City of " + name',
+    'THEN SELECT population, id, city_of'
+  ].join('\n');
+  const parser = new Parser(tokenizeForParser(script));
+  const result = parser.parseAll();
+  assert.strictEqual(result.errors.length, 1);
+  assert.strictEqual(result.errors[0].line, 4);
+  assert.strictEqual(result.ast[0].pipeline.at(-1).command, 'SELECT');
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -136,3 +136,12 @@ test('Parser parses WITH COLUMN command', () => {
   assert.strictEqual(cmd.args.columnName, 'total');
   assert.ok(Array.isArray(cmd.args.expression));
 });
+
+test('parseAll collects multiple errors', () => {
+  const script = 'VAR "x" THEN SELECT\nVAR "y" THEN JOIN';
+  const parser = new Parser(tokenizeForParser(script));
+  const result = parser.parseAll();
+  assert.strictEqual(result.errors.length, 2);
+  assert.ok(result.errors[0].line);
+  assert.ok(result.errors[1].line);
+});

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -263,20 +263,20 @@ test('debounced input updates execStatus', async () => {
   assert.ok(Array.from(bars).every(b => b.classList.contains('line-success')));
 });
 
-test('execStatus highlights error line in red', async () => {
+test('execStatus highlights error lines in red', async () => {
   setupDom();
   const interp = new Interpreter({});
   await initUI(interp);
   const input = document.getElementById('pipeDataInput');
-  input.value = 'VAR "x" SELECT A';
+  input.value = 'VAR "x" SELECT A\nVAR "y" JOIN';
   input.dispatchEvent(new window.Event('input'));
   await new Promise(r => setTimeout(r, 400));
   const bars = document.querySelectorAll('#execStatus div');
-  assert.strictEqual(bars.length, 1);
+  assert.strictEqual(bars.length, 2);
   assert.ok(bars[0].classList.contains('line-error'));
-  const dot = document.querySelector('#errorMarkers .error-dot');
-  assert.ok(dot);
-  assert.ok(dot.dataset.message.includes('Line'));
+  assert.ok(bars[1].classList.contains('line-error'));
+  const dots = document.querySelectorAll('#errorMarkers .error-dot');
+  assert.strictEqual(dots.length, 2);
 });
 
 test('blank lines remain uncolored', async () => {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -279,6 +279,28 @@ test('execStatus highlights error lines in red', async () => {
   assert.strictEqual(dots.length, 2);
 });
 
+test('valid lines after an error are not marked', async () => {
+  setupDom();
+  const interp = new Interpreter({});
+  await initUI(interp);
+  const input = document.getElementById('pipeDataInput');
+  input.value = [
+    'VAR "cities"',
+    'THEN LOAD_CSV FILE "exampleCities.csv"',
+    'THEN WITH COLUMN population_millions = population / 1000000',
+    'THEN WITH COLUMN COL city_of = "City of " + name',
+    'THEN SELECT population, id, city_of'
+  ].join('\n');
+  input.dispatchEvent(new window.Event('input'));
+  await new Promise(r => setTimeout(r, 400));
+  const bars = document.querySelectorAll('#execStatus div');
+  assert.strictEqual(bars.length, 5);
+  assert.ok(bars[3].classList.contains('line-error'));
+  assert.ok(!bars[4].classList.contains('line-error'));
+  const dots = document.querySelectorAll('#errorMarkers .error-dot');
+  assert.strictEqual(dots.length, 1);
+});
+
 test('blank lines remain uncolored', async () => {
   setupDom();
   global.Papa = { parse: (f, o) => o.complete({ data: [], meta: { fields: [] } }) };


### PR DESCRIPTION
## Summary
- accumulate parse errors via new `Parser.parseAll`
- expose error line numbers and add `errors` property
- highlight multiple errors in the UI
- update docs for new behavior
- extend tests for parsing and UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d2ed6480832586b967a84d220fb8