### PR TITLE
Add node pipeline UI and column rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ UI-related code lives under `js/ui/` and is split into several modules:
 - `peek.js` – handles PEEK output rendering and export with `generatePeekHtmlForDisplay`, `renderPeekOutputsUI`, `clearEditorPeekHighlight`, and `handleExportPeek`.
 - `fileOps.js` – browser file helpers `saveScriptToFile`, `loadScriptFromFile`, and `loadDefaultScript`.
 - `index.js` – orchestrates UI initialization, event bindings, and exports helpers used in tests.
+- `pipeline.js` – simple node-based pipeline builder converting UI steps into an AST.
 
 When modifying UI behavior keep these files in sync and update this guide if the structure changes.
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,9 @@ The UI logic now lives in dedicated modules under `js/ui/`:
 - `fileOps.js` – script file loading/saving utilities.
 - `index.js` – orchestrates initialization and event binding.
 - `pipeline.js` – experimental node-based builder with a spreadsheet view and
-  editable node configuration panel.
+  editable node configuration panel. The builder can import steps from the
+  script editor and export its nodes back into DSL text so you can switch
+  between visual editing and scripting.
 
 Interpreter operations have also been split out:
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ The UI logic now lives in dedicated modules under `js/ui/`:
 - `peek.js` – renders PEEK output and handles export.
 - `fileOps.js` – script file loading/saving utilities.
 - `index.js` – orchestrates initialization and event binding.
-- `pipeline.js` – experimental node-based builder with a spreadsheet view.
+- `pipeline.js` – experimental node-based builder with a spreadsheet view and
+  editable node configuration panel.
 
 Interpreter operations have also been split out:
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ The UI logic now lives in dedicated modules under `js/ui/`:
 - `peek.js` – renders PEEK output and handles export.
 - `fileOps.js` – script file loading/saving utilities.
 - `index.js` – orchestrates initialization and event binding.
+- `pipeline.js` – experimental node-based builder with a spreadsheet view.
 
 Interpreter operations have also been split out:
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ future logic evict the stalest datasets if memory becomes an issue.
 **ADHD Strategy:** Tackle larger features one at a time. Switch tasks if motivation wanes, but ensure completion.
 
 1.  **Transformations (Sophisticated Manipulations):**
-    * [ ] **RENAME:** Implement column renaming.
+    * [X] **RENAME:** Implement column renaming.
     * [ ] **DISTINCT:** Implement removal of duplicate rows.
     * [ ] **FILL:** Implement functions to fill missing values.
     * [ ] **More Aggregation Functions:** Add `COUNT_DISTINCT`, `MEDIAN`, `MODE`, `STDDEV`, `VARIANCE`, `FIRST`, `LAST`, `CONCAT` (group concat).

--- a/guide.md
+++ b/guide.md
@@ -140,3 +140,8 @@ currently have no effect in the interpreter.
     zero. This can help future implementations decide which datasets to evict
     when memory becomes constrained.
 
+- A visual Pipeline Builder is available in the demo. Use the **From Script**
+  button to convert the current text into editable nodes or **To Script** to
+  export the nodes back into DSL code. Both paths use the same AST and DAG so
+  cached results are shared.
+

--- a/guide.md
+++ b/guide.md
@@ -105,10 +105,17 @@ WITH COLUMN name_lower = LOWER(name)
 WITH COLUMN greeting = name + "!"
 ```
 
+### RENAME_COLUMN
+Rename a column to a new name.
+
+```pipe
+RENAME_COLUMN old_name TO new_name
+```
+
 ### Parsed but Not Yet Executed
 The tokenizer and parser recognize additional commands such as `LOAD_EXCEL`,
-`DROP_COLUMNS`, `NEW_COLUMN`, `RENAME_COLUMN`, and `SORT_BY`. These commands are
-parsed but currently have no effect in the interpreter.
+`DROP_COLUMNS`, `NEW_COLUMN`, and `SORT_BY`. These commands are parsed but
+currently have no effect in the interpreter.
 
 ## Tips
 

--- a/index.html
+++ b/index.html
@@ -100,16 +100,21 @@
             </details>
         </div>
 
-        <div class="mb-6" id="nodePipelineSection">
-            <h2 class="text-lg font-medium text-gray-700 mb-2">Node Pipeline Builder</h2>
-            <ul id="nodePipelineList" class="mb-2 list-disc list-inside text-sm text-gray-700"></ul>
-            <div class="flex flex-wrap gap-2 mb-2">
-                <button id="addUploadStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Upload</button>
-                <button id="addFilterStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Filter</button>
-                <button id="addRenameStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Rename</button>
-                <button id="addSelectStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Select</button>
+        <div class="mb-6 flex flex-col lg:flex-row gap-4" id="nodePipelineWrapper">
+            <div id="nodePipelineSection" class="lg:w-1/3 space-y-2">
+                <h2 class="text-lg font-medium text-gray-700">Pipeline Builder</h2>
+                <div id="pipelineToolbar" class="flex flex-wrap gap-2 mb-1">
+                    <button id="addUploadStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Upload</button>
+                    <button id="addFilterStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Filter</button>
+                    <button id="addRenameStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Rename</button>
+                    <button id="addSelectStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Select</button>
+                </div>
+                <ul id="nodePipelineList" class="text-sm text-gray-700 space-y-1"></ul>
+                <button id="runPipelineButton" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-4 rounded text-sm">Run Pipeline</button>
             </div>
-            <button id="runPipelineButton" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-4 rounded text-sm">Run Node Pipeline</button>
+            <div id="pipelineSpreadsheetSection" class="flex-1 overflow-auto bg-gray-50 rounded border border-gray-200 p-2">
+                <table id="pipelineDataTable" class="min-w-full text-xs table-auto"></table>
+            </div>
         </div>
 
         <div class="mt-8 p-4 bg-gray-50 rounded-lg border border-gray-200">

--- a/index.html
+++ b/index.html
@@ -101,16 +101,22 @@
         </div>
 
         <div class="mb-6 flex flex-col lg:flex-row gap-4" id="nodePipelineWrapper">
-            <div id="nodePipelineSection" class="lg:w-1/3 space-y-2">
-                <h2 class="text-lg font-medium text-gray-700">Pipeline Builder</h2>
-                <div id="pipelineToolbar" class="flex flex-wrap gap-2 mb-1">
-                    <button id="addUploadStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Upload</button>
-                    <button id="addFilterStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Filter</button>
-                    <button id="addRenameStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Rename</button>
-                    <button id="addSelectStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Select</button>
+            <div id="nodePipelineSection" class="lg:w-1/3 flex flex-col space-y-2">
+                <div>
+                    <h2 class="text-lg font-medium text-gray-700">Pipeline Builder</h2>
+                    <div id="pipelineToolbar" class="flex flex-wrap gap-2 mb-1">
+                        <button id="addUploadStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Upload</button>
+                        <button id="addFilterStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Filter</button>
+                        <button id="addRenameStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Rename</button>
+                        <button id="addSelectStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Select</button>
+                    </div>
+                    <ul id="nodePipelineList" class="text-sm text-gray-700 space-y-1 h-32 overflow-y-auto border rounded p-1"></ul>
+                    <button id="runPipelineButton" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-4 rounded text-sm mt-1">Run Pipeline</button>
                 </div>
-                <ul id="nodePipelineList" class="text-sm text-gray-700 space-y-1"></ul>
-                <button id="runPipelineButton" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-4 rounded text-sm">Run Pipeline</button>
+                <div id="nodeConfigPanel" class="bg-gray-50 border border-gray-200 rounded p-2 text-sm">
+                    <h3 class="font-medium text-gray-700 mb-1">Configure Step</h3>
+                    <div id="nodeConfigContainer" class="space-y-1"></div>
+                </div>
             </div>
             <div id="pipelineSpreadsheetSection" class="flex-1 overflow-auto bg-gray-50 rounded border border-gray-200 p-2">
                 <table id="pipelineDataTable" class="min-w-full text-xs table-auto"></table>

--- a/index.html
+++ b/index.html
@@ -111,7 +111,11 @@
                         <button id="addSelectStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Select</button>
                     </div>
                     <ul id="nodePipelineList" class="text-sm text-gray-700 space-y-1 h-32 overflow-y-auto border rounded p-1"></ul>
-                    <button id="runPipelineButton" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-4 rounded text-sm mt-1">Run Pipeline</button>
+                    <div class="flex gap-2 mt-1">
+                        <button id="runPipelineButton" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-3 rounded text-sm">Run</button>
+                        <button id="loadPipelineFromScript" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">From Script</button>
+                        <button id="exportPipelineToScript" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">To Script</button>
+                    </div>
                 </div>
                 <div id="nodeConfigPanel" class="bg-gray-50 border border-gray-200 rounded p-2 text-sm">
                     <h3 class="font-medium text-gray-700 mb-1">Configure Step</h3>

--- a/index.html
+++ b/index.html
@@ -100,11 +100,23 @@
             </details>
         </div>
 
+        <div class="mb-6" id="nodePipelineSection">
+            <h2 class="text-lg font-medium text-gray-700 mb-2">Node Pipeline Builder</h2>
+            <ul id="nodePipelineList" class="mb-2 list-disc list-inside text-sm text-gray-700"></ul>
+            <div class="flex flex-wrap gap-2 mb-2">
+                <button id="addUploadStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Upload</button>
+                <button id="addFilterStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Filter</button>
+                <button id="addRenameStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Rename</button>
+                <button id="addSelectStep" class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-1 px-3 rounded text-sm">Add Select</button>
+            </div>
+            <button id="runPipelineButton" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-4 rounded text-sm">Run Node Pipeline</button>
+        </div>
+
         <div class="mt-8 p-4 bg-gray-50 rounded-lg border border-gray-200">
             <h3 class="text-lg font-semibold text-gray-700 mb-2">Syntax Guide:</h3>
             <ul class="list-disc list-inside text-sm text-gray-600 space-y-1">
                 <li>Start pipelines with `VAR "variableName"`.</li>
-                <li>Supported: `LOAD_CSV FILE "name"`, `KEEP_COLUMNS cols` or `SELECT cols`, `JOIN var ON left = right TYPE "LEFT"`, `EXPORT_CSV TO "name"`.</li>
+                <li>Supported: `LOAD_CSV FILE "name"`, `KEEP_COLUMNS cols` or `SELECT cols`, `RENAME_COLUMN old TO new`, `JOIN var ON left = right TYPE "LEFT"`, `EXPORT_CSV TO "name"`.</li>
                 <li>Other commands are parsed but not yet interpreted for all operations.</li>
                 <li>Piping: Use `THEN`. Comments: Start with `#`.</li>
                 <li>CSV Loading uses a basic native parser.</li>

--- a/js/datasetOps.js
+++ b/js/datasetOps.js
@@ -90,6 +90,27 @@ export function withColumn(interp, args, currentDataset) {
     return result;
 }
 
+export function renameColumn(interp, args, currentDataset) {
+    const { oldName, newName } = args;
+    if (!oldName || !newName) {
+        throw new Error('RENAME_COLUMN requires oldName and newName.');
+    }
+    if (!Array.isArray(currentDataset) || currentDataset.length === 0) {
+        return [];
+    }
+    if (!Object.prototype.hasOwnProperty.call(currentDataset[0], oldName)) {
+        throw new Error(`Column '${oldName}' not found for RENAME_COLUMN in VAR "${interp.activeVariableName}".`);
+    }
+    const renamed = currentDataset.map(row => {
+        const obj = { ...row };
+        obj[newName] = obj[oldName];
+        delete obj[oldName];
+        return obj;
+    });
+    interp.log(`RENAME_COLUMN '${oldName}' to '${newName}' for VAR "${interp.activeVariableName}".`);
+    return renamed;
+}
+
 export function filterRows(interp, condition, currentDataset) {
     const evalCondition = (node, row) => {
         if (!node) return false;

--- a/js/interpreter.js
+++ b/js/interpreter.js
@@ -1,7 +1,7 @@
 // interpreter.js
 import { cities as sampleCities, people as samplePeople } from './samples.js';
 import { loadCsv, exportCsv } from './csv.js';
-import { keepColumns, withColumn, filterRows, joinDatasets } from './datasetOps.js';
+import { keepColumns, withColumn, filterRows, joinDatasets, renameColumn } from './datasetOps.js';
 import { buildDag } from './dag.js';
 
 export class Interpreter {
@@ -161,6 +161,12 @@ export class Interpreter {
                     throw new Error(`No dataset loaded for VAR "${this.activeVariableName}" to apply ${command}.`);
                 }
                 this.variables[this.activeVariableName] = keepColumns(this, args, currentDataset);
+                break;
+            case 'RENAME_COLUMN':
+                if (!Array.isArray(currentDataset)) {
+                    throw new Error(`No dataset loaded for VAR "${this.activeVariableName}" to apply RENAME_COLUMN.`);
+                }
+                this.variables[this.activeVariableName] = renameColumn(this, args, currentDataset);
                 break;
             case 'JOIN':
                 if (!Array.isArray(currentDataset)) {

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 // main.js
 import { Interpreter } from './interpreter.js';
 import { initUI } from './ui/index.js';
+import { initPipelineUI } from './ui/pipeline.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     // Query elements needed by the interpreter here, or ensure ui.js does it and provides them.
@@ -21,4 +22,5 @@ document.addEventListener('DOMContentLoaded', async () => {
     // initUI now takes the interpreter instance.
     // Parser and tokenizers are used directly within ui.js for the run button logic.
     await initUI(interpreter);
+    initPipelineUI(interpreter);
 });

--- a/js/ui/pipeline.js
+++ b/js/ui/pipeline.js
@@ -1,0 +1,96 @@
+// js/ui/pipeline.js
+
+// Simple node-based pipeline builder that reuses the existing Interpreter.
+// Each pipeline node has a type and params. The UI provides buttons to add
+// nodes and a Run button to execute the pipeline using the interpreter.
+
+export const NodeTypes = {
+    UPLOAD: 'UPLOAD',
+    FILTER: 'FILTER',
+    RENAME_COLUMN: 'RENAME_COLUMN',
+    SELECT_COLUMNS: 'SELECT_COLUMNS'
+};
+
+const nodes = [];
+
+function renderList(listEl) {
+    listEl.innerHTML = '';
+    nodes.forEach((n, i) => {
+        const li = document.createElement('li');
+        li.textContent = `${i + 1}. ${n.type}`;
+        listEl.appendChild(li);
+    });
+}
+
+export function buildAstFromNodes(nodesInput) {
+    const pipeline = [];
+    nodesInput.forEach((n, idx) => {
+        const line = idx + 1;
+        switch (n.type) {
+            case NodeTypes.UPLOAD:
+                pipeline.push({ command: 'LOAD_CSV', args: { file: n.params.file }, line });
+                break;
+            case NodeTypes.FILTER:
+                pipeline.push({ command: 'FILTER', args: n.params, line });
+                break;
+            case NodeTypes.RENAME_COLUMN:
+                pipeline.push({ command: 'RENAME_COLUMN', args: n.params, line });
+                break;
+            case NodeTypes.SELECT_COLUMNS:
+                pipeline.push({ command: 'SELECT', args: n.params, line });
+                break;
+        }
+    });
+    return [{ variableName: 'main', line: 1, pipeline }];
+}
+
+export function initPipelineUI(interpreter) {
+    const listEl = document.getElementById('nodePipelineList');
+    const runBtn = document.getElementById('runPipelineButton');
+    const addUpload = document.getElementById('addUploadStep');
+    const addFilter = document.getElementById('addFilterStep');
+    const addRename = document.getElementById('addRenameStep');
+    const addSelect = document.getElementById('addSelectStep');
+
+    if (!listEl || !runBtn) return;
+
+    function addNode(type, params) {
+        nodes.push({ type, params: params || {} });
+        renderList(listEl);
+    }
+
+    addUpload?.addEventListener('click', () => {
+        const file = prompt('CSV file name', 'exampleCities.csv');
+        if (file) addNode(NodeTypes.UPLOAD, { file });
+    });
+
+    addFilter?.addEventListener('click', () => {
+        const column = prompt('Column to filter');
+        const operator = prompt('Operator (=, !=, >, <, >=, <=, CONTAINS)');
+        const value = prompt('Value');
+        if (column && operator) {
+            addNode(NodeTypes.FILTER, { column, operator, value });
+        }
+    });
+
+    addRename?.addEventListener('click', () => {
+        const oldName = prompt('Old column name');
+        const newName = prompt('New column name');
+        if (oldName && newName) addNode(NodeTypes.RENAME_COLUMN, { oldName, newName });
+    });
+
+    addSelect?.addEventListener('click', () => {
+        const cols = prompt('Columns to keep (comma separated)');
+        if (cols) {
+            const columns = cols.split(',').map(c => c.trim()).filter(Boolean);
+            addNode(NodeTypes.SELECT_COLUMNS, { columns });
+        }
+    });
+
+    runBtn.addEventListener('click', async () => {
+        const ast = buildAstFromNodes(nodes);
+        await interpreter.run(ast);
+    });
+
+    renderList(listEl);
+}

--- a/js/ui/pipeline.js
+++ b/js/ui/pipeline.js
@@ -1,8 +1,9 @@
 // js/ui/pipeline.js
 
 // Simple node-based pipeline builder that reuses the existing Interpreter.
-// Each pipeline node has a type and params. The UI provides buttons to add
-// nodes and a Run button to execute the pipeline using the interpreter.
+// Each pipeline node has a type and params. Users can select a node to
+// configure it and preview the dataset at that point using the Interpreter's
+// DAG cache.
 
 export const NodeTypes = {
     UPLOAD: 'UPLOAD',
@@ -12,20 +13,32 @@ export const NodeTypes = {
 };
 
 const nodes = [];
+let selectedIndex = null;
+let interpreterInstance;
 
-function renderList(listEl) {
+function renderList(listEl, configEl) {
     listEl.innerHTML = '';
     nodes.forEach((n, i) => {
         const li = document.createElement('li');
-        li.className = 'flex items-center justify-between bg-gray-200 rounded px-2 py-1';
+        li.className = 'flex items-center justify-between rounded px-2 py-1 cursor-pointer';
+        li.classList.add(i === selectedIndex ? 'bg-blue-200' : 'bg-gray-200');
         const span = document.createElement('span');
         span.textContent = `${i + 1}. ${n.type}`;
         const removeBtn = document.createElement('button');
         removeBtn.textContent = '✕';
         removeBtn.className = 'text-xs text-red-600 ml-2';
-        removeBtn.addEventListener('click', () => {
+        removeBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
             nodes.splice(i, 1);
-            renderList(listEl);
+            if (selectedIndex === i) selectedIndex = null;
+            renderList(listEl, configEl);
+            renderConfig(configEl, nodes[selectedIndex]);
+        });
+        li.addEventListener('click', () => {
+            selectedIndex = i;
+            renderList(listEl, configEl);
+            renderConfig(configEl, nodes[i]);
+            runAndShow(i);
         });
         li.appendChild(span);
         li.appendChild(removeBtn);
@@ -64,6 +77,72 @@ function renderTable(tableEl, data) {
     tableEl.appendChild(tbody);
 }
 
+function renderConfig(configEl, node) {
+    if (!configEl) return;
+    configEl.innerHTML = '';
+    if (!node) {
+        configEl.textContent = 'Select a step to configure';
+        return;
+    }
+    const createInput = (labelText, key, value) => {
+        const label = document.createElement('label');
+        label.className = 'block text-xs text-gray-700 mt-1';
+        label.textContent = labelText;
+        const input = document.createElement('input');
+        input.className = 'border rounded w-full px-1 text-xs';
+        input.value = value || '';
+        input.addEventListener('change', () => {
+            if (key === 'columns') {
+                node.params.columns = input.value.split(',').map(c => c.trim()).filter(Boolean);
+            } else {
+                node.params[key] = input.value;
+            }
+            runAndShow(selectedIndex);
+        });
+        label.appendChild(input);
+        configEl.appendChild(label);
+    };
+    switch (node.type) {
+        case NodeTypes.UPLOAD:
+            createInput('File', 'file', node.params.file);
+            break;
+        case NodeTypes.FILTER:
+            createInput('Column', 'column', node.params.column);
+            createInput('Operator', 'operator', node.params.operator);
+            createInput('Value', 'value', node.params.value);
+            break;
+        case NodeTypes.RENAME_COLUMN:
+            createInput('Old Name', 'oldName', node.params.oldName);
+            createInput('New Name', 'newName', node.params.newName);
+            break;
+        case NodeTypes.SELECT_COLUMNS:
+            createInput('Columns (comma separated)', 'columns', node.params.columns ? node.params.columns.join(', ') : '');
+            break;
+    }
+}
+
+async function runAndShow(stepIndex) {
+    const ast = buildAstFromNodes(nodes);
+    await interpreterInstance.run(ast);
+    showDataset(stepIndex);
+}
+
+function showDataset(stepIndex) {
+    const tableEl = document.getElementById('pipelineDataTable');
+    if (!tableEl) return;
+    let dataset = interpreterInstance.variables.main || [];
+    if (typeof stepIndex === 'number' && stepIndex >= 0 && stepIndex < nodes.length) {
+        const stepId = `step-main-l${stepIndex + 1}-${stepIndex}`;
+        const out = interpreterInstance.stepOutputs.find(o => o.id === stepId);
+        if (out) dataset = out.dataset;
+    } else {
+        const finalId = 'step-main-l1-final';
+        const out = interpreterInstance.stepOutputs.find(o => o.id === finalId);
+        if (out) dataset = out.dataset;
+    }
+    renderTable(tableEl, dataset);
+}
+
 export function buildAstFromNodes(nodesInput) {
     const pipeline = [];
     nodesInput.forEach((n, idx) => {
@@ -87,19 +166,20 @@ export function buildAstFromNodes(nodesInput) {
 }
 
 export function initPipelineUI(interpreter) {
+    interpreterInstance = interpreter;
     const listEl = document.getElementById('nodePipelineList');
     const runBtn = document.getElementById('runPipelineButton');
     const addUpload = document.getElementById('addUploadStep');
     const addFilter = document.getElementById('addFilterStep');
     const addRename = document.getElementById('addRenameStep');
     const addSelect = document.getElementById('addSelectStep');
-    const tableEl = document.getElementById('pipelineDataTable');
+    const configEl = document.getElementById('nodeConfigContainer');
 
     if (!listEl || !runBtn) return;
 
     function addNode(type, params) {
         nodes.push({ type, params: params || {} });
-        renderList(listEl);
+        renderList(listEl, configEl);
     }
 
     addUpload?.addEventListener('click', () => {
@@ -130,14 +210,11 @@ export function initPipelineUI(interpreter) {
         }
     });
 
-    runBtn.addEventListener('click', async () => {
-        const ast = buildAstFromNodes(nodes);
-        await interpreter.run(ast);
-        if (tableEl) {
-            const data = interpreter.variables.main;
-            renderTable(tableEl, data);
-        }
+    runBtn.addEventListener('click', () => {
+        selectedIndex = nodes.length; // final output
+        runAndShow(selectedIndex);
     });
 
-    renderList(listEl);
+    renderList(listEl, configEl);
+    renderConfig(configEl, null);
 }

--- a/js/ui/pipeline.js
+++ b/js/ui/pipeline.js
@@ -17,9 +17,51 @@ function renderList(listEl) {
     listEl.innerHTML = '';
     nodes.forEach((n, i) => {
         const li = document.createElement('li');
-        li.textContent = `${i + 1}. ${n.type}`;
+        li.className = 'flex items-center justify-between bg-gray-200 rounded px-2 py-1';
+        const span = document.createElement('span');
+        span.textContent = `${i + 1}. ${n.type}`;
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = '✕';
+        removeBtn.className = 'text-xs text-red-600 ml-2';
+        removeBtn.addEventListener('click', () => {
+            nodes.splice(i, 1);
+            renderList(listEl);
+        });
+        li.appendChild(span);
+        li.appendChild(removeBtn);
         listEl.appendChild(li);
     });
+}
+
+function renderTable(tableEl, data) {
+    tableEl.innerHTML = '';
+    if (!Array.isArray(data) || data.length === 0) {
+        tableEl.textContent = 'No data';
+        return;
+    }
+    const headers = Object.keys(data[0]);
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    headers.forEach(h => {
+        const th = document.createElement('th');
+        th.textContent = h;
+        th.className = 'border px-1';
+        headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    const tbody = document.createElement('tbody');
+    data.forEach(row => {
+        const tr = document.createElement('tr');
+        headers.forEach(h => {
+            const td = document.createElement('td');
+            td.textContent = row[h];
+            td.className = 'border px-1';
+            tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+    });
+    tableEl.appendChild(thead);
+    tableEl.appendChild(tbody);
 }
 
 export function buildAstFromNodes(nodesInput) {
@@ -51,6 +93,7 @@ export function initPipelineUI(interpreter) {
     const addFilter = document.getElementById('addFilterStep');
     const addRename = document.getElementById('addRenameStep');
     const addSelect = document.getElementById('addSelectStep');
+    const tableEl = document.getElementById('pipelineDataTable');
 
     if (!listEl || !runBtn) return;
 
@@ -90,6 +133,10 @@ export function initPipelineUI(interpreter) {
     runBtn.addEventListener('click', async () => {
         const ast = buildAstFromNodes(nodes);
         await interpreter.run(ast);
+        if (tableEl) {
+            const data = interpreter.variables.main;
+            renderTable(tableEl, data);
+        }
     });
 
     renderList(listEl);

--- a/tests/interpreter.test.js
+++ b/tests/interpreter.test.js
@@ -4,7 +4,7 @@ import { Interpreter } from '../js/interpreter.js';
 import { tokenizeForParser } from '../js/tokenizer.js';
 import { Parser } from '../js/parser.js';
 import * as csv from '../js/csv.js';
-import { keepColumns, joinDatasets, filterRows, withColumn } from '../js/datasetOps.js';
+import { keepColumns, joinDatasets, filterRows, withColumn, renameColumn } from '../js/datasetOps.js';
 
 // Minimal stubs for browser APIs used in exports
 global.document = {
@@ -23,6 +23,14 @@ test('keepColumns selects columns case-insensitively', () => {
   const data = [{A:1,B:2,C:3},{A:4,B:5,C:6}];
   const result = keepColumns(interp, { columns: ['a','C'] }, data);
   assert.deepEqual(result, [{A:1,C:3},{A:4,C:6}]);
+});
+
+test('renameColumn renames a column', () => {
+  const interp = new Interpreter({});
+  interp.activeVariableName = 'r';
+  const data = [{old:1},{old:2}];
+  const result = renameColumn(interp, { oldName:'old', newName:'new' }, data);
+  assert.deepEqual(result, [{new:1},{new:2}]);
 });
 
 

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -1,6 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildAstFromNodes, NodeTypes } from '../js/ui/pipeline.js';
+import { buildAstFromNodes, buildNodesFromAst, serializeAstToScript, NodeTypes } from '../js/ui/pipeline.js';
+import { Parser } from '../js/parser.js';
+import { tokenizeForParser } from '../js/tokenizer.js';
 
 test('buildAstFromNodes converts nodes to AST', () => {
   const nodes = [
@@ -12,4 +14,23 @@ test('buildAstFromNodes converts nodes to AST', () => {
   assert.strictEqual(ast[0].pipeline.length, 2);
   assert.strictEqual(ast[0].pipeline[0].command, 'LOAD_CSV');
   assert.strictEqual(ast[0].pipeline[1].command, 'SELECT');
+});
+
+test('buildNodesFromAst converts AST to nodes', () => {
+  const ast = [{ variableName: 'main', line: 1, pipeline: [
+    { command: 'LOAD_CSV', args: { file: 'f.csv' }, line: 1 },
+    { command: 'RENAME_COLUMN', args: { oldName: 'a', newName: 'b' }, line: 2 }
+  ] }];
+  const nodes = buildNodesFromAst(ast);
+  assert.strictEqual(nodes.length, 2);
+  assert.strictEqual(nodes[0].type, NodeTypes.UPLOAD);
+  assert.strictEqual(nodes[1].type, NodeTypes.RENAME_COLUMN);
+});
+
+test('serializeAstToScript produces DSL text', () => {
+  const script = 'VAR "main"\nTHEN LOAD_CSV FILE "file.csv"\nTHEN SELECT A';
+  const { ast } = new Parser(tokenizeForParser(script)).parseAll();
+  const out = serializeAstToScript(ast);
+  assert.ok(out.includes('LOAD_CSV'));
+  assert.ok(out.includes('SELECT'));
 });

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAstFromNodes, NodeTypes } from '../js/ui/pipeline.js';
+
+test('buildAstFromNodes converts nodes to AST', () => {
+  const nodes = [
+    { type: NodeTypes.UPLOAD, params: { file: 'file.csv' } },
+    { type: NodeTypes.SELECT_COLUMNS, params: { columns: ['A'] } }
+  ];
+  const ast = buildAstFromNodes(nodes);
+  assert.strictEqual(ast.length, 1);
+  assert.strictEqual(ast[0].pipeline.length, 2);
+  assert.strictEqual(ast[0].pipeline[0].command, 'LOAD_CSV');
+  assert.strictEqual(ast[0].pipeline[1].command, 'SELECT');
+});


### PR DESCRIPTION
## Summary
- support `RENAME_COLUMN` in interpreter and dataset ops
- add simple node-based pipeline builder UI
- document new UI module and RENAME_COLUMN command
- test renameColumn and AST generation from nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ecfcf9948325b30b81ca1a8cd28a