### PR TITLE
Improve editor defaults and peek behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The UI visualizes this DAG below the editor. Nodes are arranged so that every de
 4.  **UI Features (Richer Interaction):**
     * [ ] **Visualize Pipeline (DAG):** Display the DAG to the user.
     * [ ] **Manage Multiple Inputs:** Create a UI to list and manage loaded files/datasets.
-    * [ ] **Preview Data After Each Step:** With caching, implement a reliable preview of the data after each transformation step.
+    * [X] **Preview Data After Each Step:** With caching, implement a reliable preview of the data after each transformation step.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ next to the preview outputs. Only the active output tab is visible at any time a
 each tab label shows just the variable name. Selecting a step highlights the
 first word of that line in the editor so you can trace pipeline execution.
 Moving the cursor onto a line with a recorded output automatically switches to
-that tab so you can quickly inspect results as you edit.
+that tab so you can quickly inspect results as you edit. When editing introduces
+a parse error, the peek view now reverts to the last line that produced valid
+output.
 Clicking on a line containing `VAR "name"` now shows the final value assigned to
 that variable after all of its commands run.
 
@@ -35,8 +37,9 @@ highlight syntax errors. When parse errors occur red dots appear next to each ba
 preceding command, while gaps between blocks stay uncolored. The interpreter runs
 automatically a moment after you stop typing.
 
-The editor automatically loads `examples/default.pd` on startup. The script shows
-how to compute `population_millions` with `WITH COLUMN`.
+The editor automatically loads `examples/default.pd` on startup and now runs it
+once on first launch. The script shows how to compute `population_millions` with
+`WITH COLUMN`.
 
 With a supported browser you can **Open File** or **Save File** to work directly with `.pd` script files.
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Random ideas:
 ~~* Realtime editing errors are hard to find. Also seems like they should be isolated to the line they are on (before next THEN?)~~
 * Dark mode?
 * Variable blocks formatted to identify what is and isn't in a variable?
+* Autofill column names, commands, etc.
 
 Recommended Refactorings (completed)
 

--- a/guide.md
+++ b/guide.md
@@ -61,7 +61,9 @@ Each command also records its result in a **Step Outputs** list. Only the
 currently active output tab is shown, and each tab label displays the variable
 name only. Selecting a step tab highlights the first word of that command line
 so you can follow the pipeline. Placing the cursor on a line that produced an
-output will also activate the corresponding tab automatically. Clicking on the
+output will also activate the corresponding tab automatically. If a change
+causes a parse error, the view falls back to the last line with valid output.
+Clicking on the
 `VAR` line for a pipeline shows the dataset after all of that variable's
 commands have executed. The editor shows line numbers so you can easily
 reference pipeline steps. Next to these numbers a thin gutter displays
@@ -117,8 +119,8 @@ parsed but currently have no effect in the interpreter.
 - When loading a file, the UI will prompt you to select it.
 - With a supported browser you can **Open File** or **Save File** to work
   with `.pd` files.
-- The editor loads `examples/default.pd` automatically so you can see a working
-  script right away.
+- The editor loads `examples/default.pd` automatically and runs it once on first
+  launch so you can see a working script right away.
   - Internally the parser output can be converted to a directed acyclic graph.
     Each command node has a fingerprint that ignores line numbers and includes
     the fingerprints of its dependencies, so formatting changes do not disrupt

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -45,14 +45,14 @@ function setupDom() {
 test('dag container is present after initUI', async () => {
   setupDom();
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   assert.ok(document.getElementById('dagContainer'));
 });
 
 test('renderDag creates node elements with descriptions', async () => {
   setupDom();
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   const tokens = tokenizeForParser('VAR "v" THEN SELECT A');
   const ast = new Parser(tokens).parse();
   const dag = buildDag(ast);
@@ -68,7 +68,7 @@ test('renderPeekOutputsUI creates a tab for each PEEK output', async () => {
   setupDom();
 
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   interp.peekOutputs = [
     { id: 'p1', varName: 'x', line: 1, dataset: [{A:1}] },
     { id: 'p2', varName: 'x', line: 2, dataset: [{A:2}] }
@@ -83,7 +83,7 @@ test('moving cursor selects matching peek tab', async () => {
   setupDom();
 
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   interp.peekOutputs = [
     { id: 'p1', varName: 'x', line: 1, dataset: [{A:1}] },
     { id: 'p2', varName: 'x', line: 2, dataset: [{A:2}] }
@@ -116,7 +116,7 @@ test('running script updates AST output and peek UI', async () => {
   };
 
   const interp = new Interpreter(uiEls);
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   interp.requestCsvFile = async () => ({ name: 'fake.csv' });
 
   const script = `VAR "d"
@@ -160,7 +160,7 @@ test('full chain handles multi-block script and empty dataset', async () => {
   };
 
   const interp = new Interpreter(uiEls);
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   interp.requestCsvFile = async () => ({ name: 'fake.csv' });
 
   const script = `VAR "main"
@@ -199,7 +199,7 @@ test('ui shows error message for invalid script', async () => {
     filePromptMessageEl: document.getElementById('filePromptMessage')
   };
   const interp = new Interpreter(uiEls);
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   global.fetch = async () => ({ ok: true, text: async () => 'A,B\n1,2' });
 
   const script = 'VAR "x" SELECT A';
@@ -229,7 +229,7 @@ test('ui shows error message for invalid script', async () => {
 test('saving script to file uses File System Access API', async () => {
   setupDom();
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
 
   let data = null;
   let closed = false;
@@ -251,7 +251,7 @@ test('saving script to file uses File System Access API', async () => {
 test('loading script from file populates editor', async () => {
   setupDom();
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
 
   window.showOpenFilePicker = async () => [{
     getFile: async () => new File(['VAR "z"'], 'script.pd')
@@ -274,7 +274,7 @@ test('debounced input updates execStatus', async () => {
     filePromptMessageEl: document.getElementById('filePromptMessage')
   };
   const interp = new Interpreter(uiEls);
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
 
   const input = document.getElementById('pipeDataInput');
   input.value = 'VAR "x"\nTHEN LOAD_CSV FILE "exampleCities.csv"';
@@ -291,7 +291,7 @@ test('debounced input updates execStatus', async () => {
 test('execStatus highlights error lines in red', async () => {
   setupDom();
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   const input = document.getElementById('pipeDataInput');
   input.value = 'VAR "x" SELECT A\nVAR "y" JOIN';
   input.dispatchEvent(new window.Event('input'));
@@ -307,7 +307,7 @@ test('execStatus highlights error lines in red', async () => {
 test('valid lines after an error are not marked', async () => {
   setupDom();
   const interp = new Interpreter({});
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
   const input = document.getElementById('pipeDataInput');
   input.value = [
     'VAR "cities"',
@@ -336,7 +336,7 @@ test('blank lines remain uncolored', async () => {
     filePromptMessageEl: document.getElementById('filePromptMessage')
   };
   const interp = new Interpreter(uiEls);
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
 
   const input = document.getElementById('pipeDataInput');
   input.value = 'VAR "a"\nTHEN SELECT A\n\nVAR "b"\nTHEN SELECT A\n';
@@ -361,7 +361,7 @@ test('blank line within VAR block inherits status', async () => {
     filePromptMessageEl: document.getElementById('filePromptMessage')
   };
   const interp = new Interpreter(uiEls);
-  await initUI(interp);
+  await initUI(interp, { autoRun: false });
 
   const input = document.getElementById('pipeDataInput');
   input.value = 'VAR "x"\nTHEN SELECT A\n\nTHEN SELECT A';


### PR DESCRIPTION
## Summary
- auto-run the default script once on page load
- restore last valid peek line on parse errors
- allow `initUI()` to disable auto-run for tests
- document new behavior in README and guide
- update UI tests to skip automatic run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68420018e0bc832580e6528739ef6726