### PR TITLE
Apply dark theme from demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,12 +8,12 @@
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js"></script>
     <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-gray-100 min-h-screen flex flex-col items-center p-4">
+<body class="bg-gray-900 text-gray-200 font-sans min-h-screen flex flex-col items-center p-4">
 
-    <div class="w-full max-w-6xl bg-white p-6 sm:p-8 rounded-xl shadow-2xl">
-        <header class="mb-8 text-center">
-            <h1 class="text-4xl font-bold text-gray-800">PipeData DSL Runner</h1>
-            <p class="text-gray-600 mt-2">Write PipeData script, select a CSV if needed, and run to see results.</p>
+    <div class="w-full max-w-6xl bg-gray-800 p-6 sm:p-8 rounded-xl shadow-2xl">
+        <header class="p-3 bg-gray-800 shadow-md mb-8 text-center">
+            <h1 class="text-4xl font-bold text-gray-100">PipeData DSL Runner</h1>
+            <p class="text-gray-400 mt-2">Write PipeData script, select a CSV if needed, and run to see results.</p>
             <p class="mt-1 text-right">
                 <a href="https://github.com/CodyBurker/data_dsl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium underline">
                     <svg class="w-5 h-5 mr-1 github-icon-animated" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -30,18 +30,18 @@
             </p>
         </header>
 
-        <div class="file-input-container hidden" id="fileInputContainer">
-            <label for="csvFileInput" class="block text-sm font-medium text-gray-700 mb-2">A `LOAD_CSV` command requires you to select a file:</label>
-            <input type="file" id="csvFileInput" accept=".csv,.txt" class="block w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 cursor-pointer focus:outline-none p-2">
+        <div class="file-input-container hidden bg-gray-800 border border-gray-600" id="fileInputContainer">
+            <label for="csvFileInput" class="block text-sm font-medium text-gray-300 mb-2">A `LOAD_CSV` command requires you to select a file:</label>
+            <input type="file" id="csvFileInput" accept=".csv,.txt" class="block w-full text-sm text-gray-100 bg-gray-700 rounded-lg border border-gray-600 cursor-pointer focus:outline-none p-2">
             <p id="filePromptMessage" class="text-xs text-gray-500 mt-1"></p>
         </div>
         <div class="mb-6">
-            <label class="block text-lg font-medium text-gray-700 mb-1">Datapipe View:</label>
-            <div id="dagContainer" class="border border-gray-300 rounded-lg"></div>
+            <label class="block text-lg font-medium text-gray-300 mb-1">Datapipe View:</label>
+            <div id="dagContainer" class="border border-gray-600 rounded-lg"></div>
         </div>
 
         <div class="mb-6">
-            <label for="pipeDataInput" class="block text-lg font-medium text-gray-700 mb-1">PipeData Script Editor:</label>
+            <label for="pipeDataInput" class="block text-lg font-medium text-gray-300 mb-1">PipeData Script Editor:</label>
             <div class="code-editor-container editor-prominent">
                 <pre id="lineNumbers" aria-hidden="true"></pre>
                 <div id="execStatus" aria-hidden="true"></div>
@@ -53,19 +53,19 @@
             </div>
             <div class="mt-4 flex flex-col sm:flex-row justify-end items-center gap-4">
                 <button id="openScriptFileButton"
-                    class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    class="py-2 px-4 bg-gray-700 hover:bg-gray-600 rounded-md text-indigo-400 hover:text-indigo-300 shadow-md transition-colors duration-150 w-full sm:w-auto text-sm">
                     Open File
                 </button>
                 <button id="saveScriptFileButton"
-                    class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    class="py-2 px-4 bg-gray-700 hover:bg-gray-600 rounded-md text-indigo-400 hover:text-indigo-300 shadow-md transition-colors duration-150 w-full sm:w-auto text-sm">
                     Save File
                 </button>
                 <button id="clearButton"
-                    class="bg-gray-500 hover:bg-gray-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    class="py-2 px-4 bg-gray-700 hover:bg-gray-600 rounded-md text-indigo-400 hover:text-indigo-300 shadow-md transition-colors duration-150 w-full sm:w-auto text-sm">
                     Clear Outputs
                 </button>
                 <button id="runButton"
-                    class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 w-full sm:w-auto text-sm">
+                    class="py-2 px-4 bg-gray-700 hover:bg-gray-600 rounded-md text-indigo-400 hover:text-indigo-300 shadow-md transition-colors duration-150 w-full sm:w-auto text-sm">
                     Run Script
                 </button>
             </div>
@@ -73,13 +73,13 @@
         
         <div class="mb-6">
             <div class="flex justify-between items-center mb-0">
-                <label class="block text-lg font-medium text-gray-700">PEEK Outputs:</label>
+                <label class="block text-lg font-medium text-gray-300">PEEK Outputs:</label>
                 <button id="exportPeekButton"
-                    class="bg-green-500 hover:bg-green-600 text-white font-semibold py-1 px-3 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105 text-xs hidden">
+                    class="py-1 px-3 bg-gray-700 hover:bg-gray-600 rounded-md text-indigo-400 hover:text-indigo-300 shadow-md transition-colors duration-150 text-xs hidden">
                     Export Active PEEK (CSV)
                 </button>
             </div>
-            <div id="peekTabsContainer" class="flex flex-wrap border-b border-gray-300">
+            <div id="peekTabsContainer" class="flex flex-wrap border-b border-gray-600">
                 </div>
             <div id="peekOutputsDisplayArea" class="peek-output-area-container">
                 <div class="output-box-placeholder">Peek results will appear here when a script is run.</div>
@@ -87,8 +87,8 @@
         </div>
 
         <div class="mb-6">
-            <details class="output-collapsible rounded-lg border border-gray-300">
-                <summary class="cursor-pointer p-3 font-medium text-gray-700 bg-gray-50 hover:bg-gray-100 rounded-t-lg">
+            <details class="output-collapsible rounded-lg border border-gray-600">
+                <summary class="cursor-pointer p-3 font-medium text-gray-100 bg-gray-700 hover:bg-gray-600 rounded-t-lg">
                     View AST / Parse Error
                 </summary>
                 <div id="astOutput" class="output-box output-box-collapsible-content">AST will appear here...</div>
@@ -96,17 +96,17 @@
         </div>
 
         <div class="mb-6">
-            <details class="output-collapsible rounded-lg border border-gray-300">
-                <summary class="cursor-pointer p-3 font-medium text-gray-700 bg-gray-50 hover:bg-gray-100 rounded-t-lg">
+            <details class="output-collapsible rounded-lg border border-gray-600">
+                <summary class="cursor-pointer p-3 font-medium text-gray-100 bg-gray-700 hover:bg-gray-600 rounded-t-lg">
                     View Interpreter Logs
                 </summary>
                 <div id="logOutput" class="output-box output-box-collapsible-content">Logs will appear here...</div>
             </details>
         </div>
 
-        <div class="mt-8 p-4 bg-gray-50 rounded-lg border border-gray-200">
-            <h3 class="text-lg font-semibold text-gray-700 mb-2">Syntax Guide:</h3>
-            <ul class="list-disc list-inside text-sm text-gray-600 space-y-1">
+        <div class="mt-8 p-4 bg-gray-800 rounded-lg border border-gray-600">
+            <h3 class="text-lg font-semibold text-gray-100 mb-2">Syntax Guide:</h3>
+            <ul class="list-disc list-inside text-sm text-gray-300 space-y-1">
                 <li>Start pipelines with `VAR "variableName"`.</li>
                 <li>Supported: `LOAD_CSV FILE "name"`, `KEEP_COLUMNS cols` or `SELECT cols`, `JOIN var ON left = right TYPE "LEFT"`, `EXPORT_CSV TO "name"`.</li>
                 <li>Other commands are parsed but not yet interpreted for all operations.</li>


### PR DESCRIPTION
## Summary
- align main `index.html` styling with dark theme from demo
- update container and header classes for dark mode
- restyle buttons and lists using gray backgrounds and indigo text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842034042b08325ac3ee67800fb4e04