### PR TITLE
Update docs for Electron desktop app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,12 @@
 # Agent Guidelines
 
-This project contains a browser-based DSL for manipulating CSV data. The JavaScript code uses ES modules and a small Node-based test suite.
+This project contains an Electron-based desktop app for manipulating CSV data. The JavaScript code uses ES modules and a small Node-based test suite.
 
 ## Environment Setup
 - Use Node **18+** (Node 20 is available in the Codex container).
 - Run `npm install` once to ensure dependencies are installed
-- Run `npm run dev` during development to start the Vite server and work with the React UI.
-- Run `npm run build` to generate the compiled demo in `docs/`. The CI workflow also runs this command and commits any changes so the built files always match the source. Running it locally helps avoid extra commits from CI.
-- The demo can then be viewed by opening `docs/index.html` or by serving the repo with a simple HTTP server, e.g. `npx http-server docs`.
+- Run `npm run build` to generate the compiled app in `docs/`. The CI workflow also runs this command and commits any changes so the built files always match the source. Running it locally helps avoid extra commits from CI.
+- Run `npm run desktop` to launch the Electron shell with the built files.
 
 ## Testing
 - All unit tests reside in the `tests/` directory and use Node's built-in test runner.
@@ -22,7 +21,7 @@ This project contains a browser-based DSL for manipulating CSV data. The JavaScr
 - The `js/` directory contains the tokenizer, parser, interpreter, and UI logic.
 - `js/csv.js` contains helper functions for CSV import/export used by the interpreter.
 - `js/datasetOps.js` contains dataset transformation helpers (joins, filtering, column math).
-- `index.html` loads PapaParse from a CDN for CSV processing in the browser.
+- `index.html` loads PapaParse from a CDN for CSV processing in the desktop app.
 - Style rules live in `style.css`; maintain existing formatting when making UI tweaks.
 
 ## UI Module Structure
@@ -31,7 +30,7 @@ UI-related code lives under `js/ui/` and is split into several modules:
 - `elements.js` – caches DOM nodes via `queryElements` and exports the `elements` object.
 - `highlight.js` – provides `escapeHtml` and `applySyntaxHighlighting` for the editor overlay.
 - `peek.js` – handles PEEK output rendering and export with `generatePeekHtmlForDisplay`, `renderPeekOutputsUI`, `clearEditorPeekHighlight`, and `handleExportPeek`.
-- `fileOps.js` – browser file helpers `saveScriptToFile`, `loadScriptFromFile`, and `loadDefaultScript`.
+- `fileOps.js` – file helpers `saveScriptToFile`, `loadScriptFromFile`, and `loadDefaultScript`.
 - `index.js` – orchestrates UI initialization, event bindings, and exports helpers used in tests.
 
 When modifying UI behavior keep these files in sync and update this guide if the structure changes.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # PipeData DSL Overview
 
-PipeData is a domain-specific language (DSL) designed for simple, scriptable data pipeline operations on CSV files directly in the browser. It allows users to load, transform, and preview tabular data using a readable, step-by-step syntax.
+PipeData is a domain-specific language (DSL) designed for simple, scriptable data pipeline operations on CSV files. The project now ships as an Electron desktop application that lets you load, transform, and preview tabular data using a readable, step-by-step syntax.
 
-**Mission:** To provide a simple and intuitive way to manipulate tabular data in the browser, making data processing accessible to everyone.
+**Mission:** To provide a simple and intuitive way to manipulate tabular data on the desktop, making data processing accessible to everyone.
 
 ---
 
-**Live Demo:** [Try PipeData DSL in your browser](https://codyburker.github.io/data_dsl/)
-
 **Language Guide:** [View the full DSL guide](guide.md)
 
-Run `npm run dev` to start the Vite development server.
-Run `npm run build` to generate the compiled React app in the `docs/` folder. This command also copies the `examples/` folder so the demo can load the sample CSV files. GitHub Pages serves files from that directory. The CI workflow also runs this build and commits the results so `docs/` always reflects the latest source code.
+Run `npm run build` to generate the compiled React app in the `docs/` folder. This command also copies the `examples/` folder so the desktop app can load the sample CSV files. The CI workflow also runs this build and commits the results so `docs/` always reflects the latest source code.
 Run `npm run desktop` to build the React app and launch it in the Electron shell.
 Use `npm run package` to create desktop installers with `electron-builder` for Windows, macOS, and Linux.
 Pushing to the `main` branch triggers a workflow that builds these installers for all platforms and uploads them as artifacts on GitHub.
@@ -48,7 +45,7 @@ The editor automatically loads `examples/default.pd` on startup and runs it once
 on first launch. The new script demonstrates joining three datasets and using
 `GROUP_BY` and `AGGREGATE` to summarize sales by customer.
 
-With a supported browser you can **Open File** or **Save File** to work directly with `.pd` script files.
+Use the File menu in the desktop app to **Open** or **Save** `.pd` script files.
 
 ### DAG Representation
 
@@ -160,7 +157,6 @@ The UI visualizes this DAG below the editor. Nodes are arranged so that every de
 **Goal** Add spreadsheet UI, with GUI for data manipulation that builds AST, and the option to switch back and forth between GUI and text editor.
 
 ## Refactor
-Make it an electron app to make file management easier?
 Integrate AG Grid
-Export to excel
-Make panels resziable (or even movable?)
+Export to Excel
+Make panels resizable (or even movable?)

--- a/guide.md
+++ b/guide.md
@@ -1,6 +1,6 @@
 # PipeData Language Guide
 
-PipeData is a small domain-specific language for manipulating CSV data directly in the browser.
+PipeData is a small domain-specific language for manipulating CSV data in a desktop environment powered by Electron.
 This guide covers the core syntax and currently supported commands.
 
 ## Basics
@@ -35,14 +35,14 @@ VAR "myVar"
 ```
 
 ### LOAD_CSV
-Load data from a CSV file chosen in the browser.
+Load data from a CSV file on your computer.
 
 ```
 LOAD_CSV FILE "file.csv"
 ```
 
 ### LOAD_JSON
-Load data from a JSON file chosen in the browser. The file must contain an array of objects at the top level or under the optional `ROOT` key.
+Load data from a JSON file on your computer. The file must contain an array of objects at the top level or under the optional `ROOT` key.
 
 ```
 LOAD_JSON FILE "file.json"
@@ -178,8 +178,7 @@ currently has no effect in the interpreter.
 - Chain multiple commands with `THEN` to build a pipeline.
 - Comments can appear on their own line or after a command.
 - When loading a file, the UI will prompt you to select it.
-- With a supported browser you can **Open File** or **Save File** to work
-  with `.pd` files.
+- Use the desktop app's File menu to **Open** or **Save** `.pd` files.
 - The editor loads `examples/default.pd` automatically and runs it once on first
   launch so you can see a working script right away. The bundled example joins
   city, people, and sales data and aggregates total revenue per customer.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data_dsl",
   "version": "1.0.0",
-  "description": "DSL for manipulating CSV data in the browser",
+  "description": "DSL for manipulating CSV data in an Electron desktop app",
   "type": "module",
   "main": "electron/main.js",
   "author": "PipeData",


### PR DESCRIPTION
## Summary
- update README mission and instructions for Electron
- revise tips about opening files in the desktop app
- adjust Agent guidelines for desktop development
- update DSL guide to remove browser references
- clarify package description

## Testing
- `npm install`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68433bfccecc832586a1196e64318232